### PR TITLE
Semester click reset queries

### DIFF
--- a/src/api/words/interfaces/index.ts
+++ b/src/api/words/interfaces/index.ts
@@ -17,6 +17,16 @@ export interface WordData extends DataStatus, DataBasics {
   dateAdded?: number
 }
 
+export interface PostWordReqDto {
+  languageCode: GlobalLanguageCode
+  isFavorite: boolean
+  term: string
+  pronunciation: string
+  definition: string
+  example: string
+  tags: string[]
+}
+
 export type WordDataModifiable = Omit<WordData, 'id'>
 export type WordDataModifiableString = Omit<
   WordDataModifiable,

--- a/src/api/words/post-word.api.ts
+++ b/src/api/words/post-word.api.ts
@@ -1,6 +1,6 @@
 import { CustomizedAxiosResponse } from '../index.interface'
 import axios from 'axios'
-import { WordData } from './interfaces'
+import { PostWordReqDto, WordData } from './interfaces'
 import { GetSemestersResDTO } from '../semesters/get-semesters.api'
 
 interface PostWordRes {
@@ -9,7 +9,7 @@ interface PostWordRes {
 }
 
 export const postWordApi = async (
-  newWord: WordData,
+  newWord: PostWordReqDto,
 ): Promise<CustomizedAxiosResponse<PostWordRes>> => {
   const url = `/v1/words`
   const res = await axios.post(url, newWord)

--- a/src/components/atom_tag_button/index.semester.tsx
+++ b/src/components/atom_tag_button/index.semester.tsx
@@ -28,6 +28,9 @@ const TagButtonSemester: FC<Props> = ({ semester }) => {
         semester: code,
         pageIndex: 0, // must reset page index
         daysAgo: undefined, // must reset days ago
+        languageCodes: undefined, // must reset language codes
+        isFavorite: undefined, // must reset is favorite
+        tags: undefined, // must reset tags
       })
     },
     [code, selectedSemester, getWords],

--- a/src/components/atom_tag_button/index.semester.tsx
+++ b/src/components/atom_tag_button/index.semester.tsx
@@ -27,6 +27,7 @@ const TagButtonSemester: FC<Props> = ({ semester }) => {
       await getWords({
         semester: code,
         pageIndex: 0, // must reset page index
+        daysAgo: undefined, // must reset days ago
       })
     },
     [code, selectedSemester, getWords],

--- a/src/hooks/words/use-post-word-with-string.hook.ts
+++ b/src/hooks/words/use-post-word-with-string.hook.ts
@@ -1,4 +1,4 @@
-import { WordData } from '@/api/words/interfaces'
+import { PostWordReqDto } from '@/api/words/interfaces'
 import { parseInputIntoWordLambda } from '@/lambdas/parse-input-into-word.lambda'
 import { useCallback, useState, Dispatch, SetStateAction } from 'react'
 import { usePostWord } from './use-post-word.hook'
@@ -22,7 +22,7 @@ export const usePostWordWithStringHook = (): UsePostWordWithStringHook => {
     if (!userInput) return setWritingMode(false)
 
     try {
-      const newWord: WordData = parseInputIntoWordLambda(userInput)
+      const newWord: PostWordReqDto = parseInputIntoWordLambda(userInput)
       handlePostWord(newWord)
     } catch {}
 

--- a/src/hooks/words/use-post-word.hook.ts
+++ b/src/hooks/words/use-post-word.hook.ts
@@ -1,15 +1,15 @@
 import { postWordApi } from '@/api/words/post-word.api'
-import { WordData } from '@/api/words/interfaces'
+import { PostWordReqDto } from '@/api/words/interfaces'
 import { wordIdsState, wordsFamily } from '@/recoil/words/words.state'
 import { useRecoilCallback } from 'recoil'
 import { semestersState } from '@/recoil/words/semesters.state'
 
-type UsePostWord = (newWord: WordData) => Promise<void> // handlePostWord
+type UsePostWord = (newWord: PostWordReqDto) => Promise<void> // handlePostWord
 
 export const usePostWord = (): UsePostWord => {
   const handlePostWord = useRecoilCallback(
     ({ set, snapshot }) =>
-      async (newWord: WordData) => {
+      async (newWord: PostWordReqDto) => {
         try {
           const [{ postedWord, semesters }] = await postWordApi(newWord)
 

--- a/src/lambdas/parse-input-into-word.lambda.ts
+++ b/src/lambdas/parse-input-into-word.lambda.ts
@@ -1,7 +1,6 @@
 // ! Fully tested and confirmed on Jan 8, 2023
 
-import { WordData } from '@/api/words/interfaces'
-import { getRandomHexHandler } from '@/handlers/get-random-hex.handler'
+import { PostWordReqDto } from '@/api/words/interfaces'
 import { stringSliceHandler } from '@/handlers/string-slice.handler'
 
 const PRIVATE_FINAL_ESCAPE_CHAR = `$`
@@ -10,7 +9,7 @@ const PRIVATE_FINAL_EXAMPLE_CHAR = `=`
 const PRIVATE_FINAL_DEFINITION_CHARS = [`:`, `]`]
 const PRIVATE_FINAL_PRONUNCIATION_CHAR = `[`
 
-export const parseInputIntoWordLambda = (given: string): WordData => {
+export const parseInputIntoWordLambda = (given: string): PostWordReqDto => {
   const tags: string[] = []
   let leftOverAfterTags: string = given
 
@@ -45,11 +44,7 @@ export const parseInputIntoWordLambda = (given: string): WordData => {
   )
 
   return {
-    id: given + getRandomHexHandler(),
-    userId: ``, // TODO: Is this correct? I think IWord should have PostWord interface that has no userId
     languageCode: `en`,
-    semester: 231, // TODO: Remove, its only for test. Semester value should be created by server
-    createdAt: new Date().toString(),
     term: term.trim(),
     pronunciation: pronunciation.trim(),
     definition: definition.trim(),

--- a/src/lambdas/parse-input-into-word.lambda.ts
+++ b/src/lambdas/parse-input-into-word.lambda.ts
@@ -44,6 +44,7 @@ export const parseInputIntoWordLambda = (given: string): PostWordReqDto => {
   )
 
   return {
+    // TODO: Language code will be eventually modifiable
     languageCode: `en`,
     term: term.trim(),
     pronunciation: pronunciation.trim(),


### PR DESCRIPTION
## Issue
_None_

## Background
When you click a semester, your search queries like selected languages, tags, and others must be deselected.