### PR TITLE
Loading icons For Delete

### DIFF
--- a/src/atoms/StyledTextButton.tsx
+++ b/src/atoms/StyledTextButton.tsx
@@ -30,7 +30,6 @@ const StyledTextButtonAtom: FC<StyledTextButtonProps> = ({
       <Tooltip
         title={props.hoverMessage?.title || ``}
         placement={props.hoverMessage?.placement || `bottom`}
-        hidden={props.isLoading || props.isDisabled}
       >
         <span style={{ cursor: !props.hoverMessage ? undefined : `help` }}>
           <LoadingButton

--- a/src/components/atom_word_card_delete_button/index.tsx
+++ b/src/components/atom_word_card_delete_button/index.tsx
@@ -6,11 +6,12 @@ interface Props {
   wordId: string
 }
 const WordCardDeleteButton: FC<Props> = ({ wordId }) => {
-  const handleClickDeleteWord = useDeleteWord(wordId)
+  const [isDeleting, onDeleteWord] = useDeleteWord(wordId)
 
   return (
     <StyledIconButtonAtom
-      onClick={handleClickDeleteWord}
+      isDisabled={isDeleting}
+      onClick={onDeleteWord}
       jsxElementButton={<DeleteWordIcon />}
     />
   )

--- a/src/components/atom_word_card_undo_delete_button/index.tsx
+++ b/src/components/atom_word_card_undo_delete_button/index.tsx
@@ -7,13 +7,23 @@ interface Props {
   wordId: string
 }
 const WordCardUndoDeleteButton: FC<Props> = ({ wordId }) => {
-  const handleDeleteWordCache = useDeleteWordCache(wordId)
-  const handlePostWordFromUndo = usePostWordFromUndo(wordId)
+  const [loadingCache, onDeleteWordCache] = useDeleteWordCache(wordId)
+  const [loadingUndo, onPostWordFromUndo] = usePostWordFromUndo(wordId)
 
   return (
     <Fragment>
-      <StyledTextButtonAtom title={`Undo`} onClick={handlePostWordFromUndo} />
-      <StyledTextButtonAtom title={`Hide`} onClick={handleDeleteWordCache} />
+      <StyledTextButtonAtom
+        isLoading={loadingUndo}
+        isDisabled={loadingCache}
+        title={`Undo`}
+        onClick={onPostWordFromUndo}
+      />
+      <StyledTextButtonAtom
+        isLoading={loadingCache}
+        isDisabled={loadingUndo}
+        title={`Hide`}
+        onClick={onDeleteWordCache}
+      />
     </Fragment>
   )
 }

--- a/src/hooks/words/use-delete-word.hook.ts
+++ b/src/hooks/words/use-delete-word.hook.ts
@@ -1,11 +1,16 @@
 import { deleteWordByIdApi } from '@/api/words/delete-words.api'
 import { wordsFamily } from '@/recoil/words/words.state'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { useRecoilCallback } from 'recoil'
 
-type UseDeleteWord = () => Promise<void> // handleDeleteWord
+type UseDeleteWord = [
+  boolean,
+  () => Promise<void>, // handleDeleteWord
+]
 
 export const useDeleteWord = (deletingWordId: string): UseDeleteWord => {
+  const [isDeleting, setDeleting] = useState(false)
+
   const setWord = useRecoilCallback(
     ({ snapshot, set }) =>
       async (wordId: string) => {
@@ -20,12 +25,15 @@ export const useDeleteWord = (deletingWordId: string): UseDeleteWord => {
     [],
   )
 
-  const handleDeleteWord = useCallback(async () => {
+  const onDeleteWord = useCallback(async () => {
     try {
+      setDeleting(true)
       await deleteWordByIdApi(deletingWordId)
       setWord(deletingWordId)
-    } catch {}
+    } finally {
+      setDeleting(false)
+    }
   }, [deletingWordId, setWord])
 
-  return handleDeleteWord
+  return [isDeleting, onDeleteWord]
 }

--- a/src/hooks/words/use-post-word-from-undo.hook.ts
+++ b/src/hooks/words/use-post-word-from-undo.hook.ts
@@ -3,30 +3,43 @@ import { wordsFamily } from '@/recoil/words/words.state'
 import { useRecoilCallback } from 'recoil'
 import { wordIdsState } from '@/recoil/words/words.state'
 import { semestersState } from '@/recoil/words/semesters.state'
+import { useState } from 'react'
 
-type UsePostWordFromUndo = () => Promise<void> // handlePostWordFromUndo
+type UsePostWordFromUndo = [
+  boolean,
+  () => Promise<void>, // handlePostWordFromUndo
+]
 
 export const usePostWordFromUndo = (
   undoingWordId: string,
 ): UsePostWordFromUndo => {
-  const handlePostWordFromUndo = useRecoilCallback(
+  const [loading, setLoading] = useState(false)
+
+  const onPostWordFromUndo = useRecoilCallback(
     ({ set, snapshot }) =>
       async () => {
-        const word = await snapshot.getPromise(wordsFamily(undoingWordId))
-        if (!word) return // failed to re-post word
+        try {
+          setLoading(true)
+          const word = await snapshot.getPromise(wordsFamily(undoingWordId))
+          if (!word) return // failed to re-post word
 
-        const [{ postedWord, semesters }] = await postWordApi(word)
-        const wordIds = (await snapshot.getPromise(wordIdsState)).map((id) => {
-          if (id === undoingWordId) return postedWord.id
-          return id
-        })
+          const [{ postedWord, semesters }] = await postWordApi(word)
+          const wordIds = (await snapshot.getPromise(wordIdsState)).map(
+            (id) => {
+              if (id === undoingWordId) return postedWord.id
+              return id
+            },
+          )
 
-        set(wordIdsState, wordIds)
-        set(wordsFamily(postedWord.id), postedWord)
-        set(semestersState, semesters.semesters)
+          set(wordIdsState, wordIds)
+          set(wordsFamily(postedWord.id), postedWord)
+          set(semestersState, semesters.semesters)
+        } finally {
+          setLoading(false)
+        }
       },
     [undoingWordId],
   )
 
-  return handlePostWordFromUndo
+  return [loading, onPostWordFromUndo]
 }


### PR DESCRIPTION
# Background
When a user wants to delete his/her own word, it has no loading design so it is a bit confusing

![image](https://github.com/ajktown/wordnote/assets/53258958/946fc6a9-1238-49ea-8ba6-3a1c4da7edd2)


## TODOs
- [x] Loading for the followings
  - Trashcan
  - Undo
  - Hide
- [x] Fix the bug of hidden of src/atoms/StyledTextButton.tsx
- [x] Refactor delete related hooks

## Checklists
- [x] One of the followings is handled
  - At least one or more issue is linked to this PR
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) has been replaced to the [issue](#issue) above, if no issue is related to this PR
- [x] Assignee is set
- [x] Labels are set
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked
