### PR TITLE
Link for Example

### DIFF
--- a/src/api/words/interfaces/index.ts
+++ b/src/api/words/interfaces/index.ts
@@ -13,6 +13,7 @@ export interface WordData extends DataStatus, DataBasics {
   pronunciation: string
   definition: string
   example: string
+  exampleLink: string
   tags: string[]
   dateAdded?: number
 }
@@ -24,6 +25,7 @@ export interface PostWordReqDto {
   pronunciation: string
   definition: string
   example: string
+  exampleLink: string
   tags: string[]
 }
 

--- a/src/components/atom_word_card_confirm_modify_button/index.tsx
+++ b/src/components/atom_word_card_confirm_modify_button/index.tsx
@@ -16,12 +16,17 @@ const WordCardConfirmModifyButton: FC<Props> = ({ wordId }) => {
   )
   const [, , isDefinitionModified] = usePutWordCacheByKey(wordId, `definition`)
   const [, , isExampleModified] = usePutWordCacheByKey(wordId, `example`)
+  const [, , isExampleLinkModified] = usePutWordCacheByKey(
+    wordId,
+    `exampleLink`,
+  )
 
   if (
     !isTermModified &&
     !isPronunciationModified &&
     !isDefinitionModified &&
-    !isExampleModified
+    !isExampleModified &&
+    !isExampleLinkModified
   )
     return null
 

--- a/src/components/atom_word_card_parts/index.example.tsx
+++ b/src/components/atom_word_card_parts/index.example.tsx
@@ -6,6 +6,13 @@ import { Typography } from '@mui/material'
 interface Props {
   word: WordData
 }
+/**
+ * @returns
+ *  4 cases to handle:
+ *   If exampleLink does not exist, return example despite if it is empty or not. (Handles 2 cases)
+ *   If exampleLink exists, but example does not exist, return Sample Example (Handles 2 cases)
+ *   If both exampleLink and example exist, return example with link (Handles 2 cases)
+ */
 const WordCardExamplePart: FC<Props> = ({ word }) => {
   const trimmedExample = word.example.trim()
   const trimmedExampleLink = word.exampleLink.trim()
@@ -17,11 +24,11 @@ const WordCardExamplePart: FC<Props> = ({ word }) => {
       </Link>
     )
 
-  if (trimmedExampleLink === ``) return <Typography>{trimmedExampleLink}</Typography>
+  if (!trimmedExampleLink) return <Typography>{trimmedExampleLink}</Typography>
 
   return (
     <Link href={trimmedExampleLink} target="_blank">
-      {word.example}
+      {trimmedExample}
     </Link>
   )
 }

--- a/src/components/atom_word_card_parts/index.example.tsx
+++ b/src/components/atom_word_card_parts/index.example.tsx
@@ -1,20 +1,26 @@
 import { FC } from 'react'
 import { WordData } from '@/api/words/interfaces'
 import Link from 'next/link'
+import { Typography } from '@mui/material'
 
 interface Props {
   word: WordData
 }
 const WordCardExamplePart: FC<Props> = ({ word }) => {
-  if (word.example.trim() === `` && word.exampleLink)
+  const trimmedExample = word.example.trim()
+  const trimmedExampleLink = word.exampleLink.trim()
+
+  if (trimmedExample === `` && trimmedExampleLink)
     return (
-      <Link href={word.exampleLink} target="_blank">
+      <Link href={trimmedExampleLink} target="_blank">
         Sample Example
       </Link>
     )
 
+  if (trimmedExampleLink === ``) return <Typography>{trimmedExampleLink}</Typography>
+
   return (
-    <Link href={word.exampleLink} target="_blank">
+    <Link href={trimmedExampleLink} target="_blank">
       {word.example}
     </Link>
   )

--- a/src/components/atom_word_card_parts/index.example.tsx
+++ b/src/components/atom_word_card_parts/index.example.tsx
@@ -1,0 +1,23 @@
+import { FC } from 'react'
+import { WordData } from '@/api/words/interfaces'
+import Link from 'next/link'
+
+interface Props {
+  word: WordData
+}
+const WordCardExamplePart: FC<Props> = ({ word }) => {
+  if (word.example.trim() === `` && word.exampleLink)
+    return (
+      <Link href={word.exampleLink} target="_blank">
+        Sample Example
+      </Link>
+    )
+
+  return (
+    <Link href={word.exampleLink} target="_blank">
+      {word.example}
+    </Link>
+  )
+}
+
+export default WordCardExamplePart

--- a/src/components/molecule_word_card/index.editing_mode.tsx
+++ b/src/components/molecule_word_card/index.editing_mode.tsx
@@ -26,6 +26,7 @@ const WordCardEditingMode: FC<Props> = ({ wordId }) => {
             />
             <WordCardEditingTextField wordKey={`definition`} wordId={wordId} />
             <WordCardEditingTextField wordKey={`example`} wordId={wordId} />
+            <WordCardEditingTextField wordKey={`exampleLink`} wordId={wordId} />
             <TagButtonDeletableChunk wordId={wordId} />
           </Stack>
         </CardContent>

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -14,6 +14,7 @@ import WordCardEditingMode from './index.editing_mode'
 import TagButtonChunk from '../molecule_tag_button_chunk'
 import WordCardSkeleton from './index.skeleton'
 import DictLinkButtonChunk from '../molecule_dict_link_button_chunk'
+import WordCardExamplePart from '../atom_word_card_parts/index.example'
 
 interface Props {
   wordId: string
@@ -47,8 +48,8 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           <Typography variant="body2">
             {word.definition}
             <br />
-            {word.example && `"${word.example}"`}
           </Typography>
+          <WordCardExamplePart word={word} />
         </CardContent>
         <CardActions>
           <WordCardFavoriteIcon wordId={wordId} />

--- a/src/components/molecule_word_card_editing_text_field/index.tsx
+++ b/src/components/molecule_word_card_editing_text_field/index.tsx
@@ -21,6 +21,8 @@ const privateGetPlaceholder = (key: WordDataModifiableKey) => {
       return `Word`
     case `example`:
       return `Example Sentence`
+    case `exampleLink`:
+      return `Example Sentence Link`
     default:
       return stringCaseHandler.toSentence(key)
   }

--- a/src/hooks/words/use-put-word-cache.hook.ts
+++ b/src/hooks/words/use-put-word-cache.hook.ts
@@ -41,6 +41,7 @@ export const usePutWordCache = (wordId: string | null): UsePutWordCache => {
         ...(await getObjectWithKey(`pronunciation`)),
         ...(await getObjectWithKey(`definition`)),
         ...(await getObjectWithKey(`example`)),
+        ...(await getObjectWithKey(`exampleLink`)),
       }
     },
     [getObjectWithKey],
@@ -67,6 +68,7 @@ export const usePutWordCache = (wordId: string | null): UsePutWordCache => {
     await handleResetByKey(`pronunciation`)
     await handleResetByKey(`definition`)
     await handleResetByKey(`example`)
+    await handleResetByKey(`exampleLink`)
   }, [handleResetByKey])
 
   const handleApplyCache = useRecoilCallback(
@@ -83,6 +85,7 @@ export const usePutWordCache = (wordId: string | null): UsePutWordCache => {
         const [modifiedWord] = await putWordByIdApi(wordId, modified)
         set(wordsFamily(wordId), modifiedWord)
 
+        // TODO: This is causing first deletion and then creation for UI
         await handleResetCache()
       },
     [wordId, handleResetCache],

--- a/src/lambdas/parse-input-into-word.lambda.ts
+++ b/src/lambdas/parse-input-into-word.lambda.ts
@@ -50,6 +50,7 @@ export const parseInputIntoWordLambda = (given: string): PostWordReqDto => {
     pronunciation: pronunciation.trim(),
     definition: definition.trim(),
     example: example.trim(),
+    exampleLink: ``,
     isFavorite: false,
     tags,
   }


### PR DESCRIPTION
# Background
When you study word, you want to know where you get the words. Wordnote now supports link for example sentence to make yourself remember your words even more.

## TODOs
- [x] Be able to send request with exampleLink ""
- [x] Shows the link with UI

## Related PRs
- https://github.com/ajktown/docs/pull/21
- https://github.com/ajktown/api/pull/56
- https://github.com/ajktown/wordnote/pull/87

## Checklists
- [x] One of the followings is handled
  - At least one or more issue is linked to this PR
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) has been replaced to the [issue](#issue) above, if no issue is related to this PR
- [x] Related PR is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked
