### PR TITLE
Appropriate file name for selector

### DIFF
--- a/src/components/atom_tag_button/index.all_semesters.tsx
+++ b/src/components/atom_tag_button/index.all_semesters.tsx
@@ -1,7 +1,7 @@
 import StyledTagButtonAtom from '@/atoms/StyledTagButton'
 import { GlobalMuiTagVariant } from '@/global.interface'
 import { useWords } from '@/hooks/words/use-words.hook'
-import { selectedSemesterSelector } from '@/recoil/words/tags.selectors'
+import { selectedSemesterSelector } from '@/recoil/words/words.selectors'
 import { FC, useCallback, useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 

--- a/src/components/atom_tag_button/index.customized.tsx
+++ b/src/components/atom_tag_button/index.customized.tsx
@@ -1,7 +1,7 @@
 import StyledTagButtonAtom from '@/atoms/StyledTagButton'
 import { GlobalMuiTagVariant } from '@/global.interface'
 import { useWords } from '@/hooks/words/use-words.hook'
-import { selectedCustomizedTagsSelector } from '@/recoil/words/tags.selectors'
+import { selectedCustomizedTagsSelector } from '@/recoil/words/words.selectors'
 import { FC, useCallback, useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 

--- a/src/components/atom_tag_button/index.days_ago.tsx
+++ b/src/components/atom_tag_button/index.days_ago.tsx
@@ -4,7 +4,7 @@ import { useRecoilValue } from 'recoil'
 import { GlobalMuiTagVariant } from '@/global.interface'
 import { DateTime } from 'luxon'
 import { stringCaseHandler } from '@/handlers/string-case.handler'
-import { selectedDaysAgoTagsSelector } from '@/recoil/words/tags.selectors'
+import { selectedDaysAgoTagsSelector } from '@/recoil/words/words.selectors'
 import { useWords } from '@/hooks/words/use-words.hook'
 interface Props {
   daysAgo: number

--- a/src/components/atom_tag_button/index.favorite.tsx
+++ b/src/components/atom_tag_button/index.favorite.tsx
@@ -2,7 +2,7 @@ import StyledIconButtonFavorite from '@/atoms/StyledIconButtonFavorite'
 import StyledTagButtonAtom from '@/atoms/StyledTagButton'
 import { GlobalMuiTagVariant } from '@/global.interface'
 import { useWords } from '@/hooks/words/use-words.hook'
-import { isFavoriteClickedSelector } from '@/recoil/words/tags.selectors'
+import { isFavoriteClickedSelector } from '@/recoil/words/words.selectors'
 import { FC, useCallback, useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 

--- a/src/components/atom_tag_button/index.language.tsx
+++ b/src/components/atom_tag_button/index.language.tsx
@@ -2,7 +2,7 @@ import StyledTagButtonAtom from '@/atoms/StyledTagButton'
 import { PROTECTED_AVAILABLE_LANGUAGES } from '@/global.constants'
 import { GlobalLanguageCode } from '@/global.interface'
 import { useWords } from '@/hooks/words/use-words.hook'
-import { selectedLanguageTagsSelector } from '@/recoil/words/tags.selectors'
+import { selectedLanguageTagsSelector } from '@/recoil/words/words.selectors'
 import { FC, useCallback } from 'react'
 import { useRecoilValue } from 'recoil'
 

--- a/src/components/atom_tag_button/index.semester.tsx
+++ b/src/components/atom_tag_button/index.semester.tsx
@@ -2,7 +2,7 @@ import { ISemester } from '@/api/semesters/index.interface'
 import StyledTagButtonAtom from '@/atoms/StyledTagButton'
 import { GlobalMuiTagVariant } from '@/global.interface'
 import { useSemesterClick } from '@/hooks/semesters/use-semester-click.hook'
-import { selectedSemesterSelector } from '@/recoil/words/tags.selectors'
+import { selectedSemesterSelector } from '@/recoil/words/words.selectors'
 import { FC, useCallback, useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 

--- a/src/components/atom_word_cards_frame_surfing_button/index.tsx
+++ b/src/components/atom_word_cards_frame_surfing_button/index.tsx
@@ -4,7 +4,7 @@ import { FC } from 'react'
 import { useSemesterClick } from '@/hooks/semesters/use-semester-click.hook'
 import { useRecoilCallback, useRecoilValue } from 'recoil'
 import { semestersState } from '@/recoil/words/semesters.state'
-import { selectedSemesterSelector } from '@/recoil/words/tags.selectors'
+import { selectedSemesterSelector } from '@/recoil/words/words.selectors'
 
 const WordCardsFrameSurfingButton: FC = () => {
   const [, onSemesterClick] = useSemesterClick()

--- a/src/components/atom_word_cards_frame_surfing_button/index.tsx
+++ b/src/components/atom_word_cards_frame_surfing_button/index.tsx
@@ -3,8 +3,11 @@ import SurfingIcon from '@mui/icons-material/Surfing'
 import { FC } from 'react'
 import { useSemesterClick } from '@/hooks/semesters/use-semester-click.hook'
 import { useRecoilCallback, useRecoilValue } from 'recoil'
-import { semestersState } from '@/recoil/words/semesters.state'
-import { selectedSemesterSelector, semestersState } from '@/recoil/words/words.selectors'
+import {
+  isSemesterExpandedState,
+  semestersState,
+} from '@/recoil/words/semesters.state'
+import { selectedSemesterSelector } from '@/recoil/words/words.selectors'
 
 const WordCardsFrameSurfingButton: FC = () => {
   const [, onSemesterClick] = useSemesterClick()

--- a/src/components/molecule_choose_semester/index.tsx
+++ b/src/components/molecule_choose_semester/index.tsx
@@ -1,7 +1,7 @@
 import { semestersState } from '@/recoil/words/semesters.state'
 import { FC } from 'react'
 import { useRecoilValue } from 'recoil'
-import { selectedSemesterSelector } from '@/recoil/words/tags.selectors'
+import { selectedSemesterSelector } from '@/recoil/words/words.selectors'
 
 // TODO: ChooseSemester not used. will be possibly deleted in future.
 const ChooseSemester: FC = () => {

--- a/src/components/molecule_tag_button_chunk/index.detailed.tsx
+++ b/src/components/molecule_tag_button_chunk/index.detailed.tsx
@@ -6,7 +6,7 @@ import TagButtonFavorite from '../atom_tag_button/index.favorite'
 import TagButtonCustomized from '../atom_tag_button/index.customized'
 import TagButtonDaysAgo from '../atom_tag_button/index.days_ago'
 import { semesterDetailsFamily } from '@/recoil/words/semesters.state'
-import { selectedSemesterSelector } from '@/recoil/words/tags.selectors'
+import { selectedSemesterSelector } from '@/recoil/words/words.selectors'
 
 // TODO: move this somewhere else? Maybe should be stored in the database? At least API?
 const visibleDaysAgoChunk = [0, 1, 4, 7, 14, 21, 30]

--- a/src/components/organism_word_card_chunk/index.no_words_found.tsx
+++ b/src/components/organism_word_card_chunk/index.no_words_found.tsx
@@ -1,5 +1,5 @@
 import { deprecatedSelectedSemesterState } from '@/recoil/words/semesters.state'
-import { isFavoriteClickedSelector } from '@/recoil/words/tags.selectors'
+import { isFavoriteClickedSelector } from '@/recoil/words/words.selectors'
 import { Typography, Stack } from '@mui/material'
 import { FC, Fragment } from 'react'
 import { useRecoilValue } from 'recoil'

--- a/src/hooks/words/use-put-word-favorite.hook.ts
+++ b/src/hooks/words/use-put-word-favorite.hook.ts
@@ -6,7 +6,7 @@ import {
 } from '@/recoil/words/words.state'
 import { usePutWord } from '@/hooks/words/use-put-word.hook'
 import { WordData } from '@/api/words/interfaces'
-import { isFavoriteClickedSelector } from '@/recoil/words/tags.selectors'
+import { isFavoriteClickedSelector } from '@/recoil/words/words.selectors'
 
 type UsePutWord = [undefined | null | WordData, () => Promise<void>]
 export const usePutWordFavorite = (wordId: string): UsePutWord => {

--- a/src/recoil/app/app.selectors.ts
+++ b/src/recoil/app/app.selectors.ts
@@ -1,3 +1,7 @@
+/**
+ * This file contains all the selectors for the app.state.ts
+ */
+
 import { Rkp, Rks } from '@/recoil/index.keys'
 import { selector } from 'recoil'
 import { authPrepState } from './app.state'

--- a/src/recoil/words/words.selectors.ts
+++ b/src/recoil/words/words.selectors.ts
@@ -1,3 +1,6 @@
+/**
+ * This file contains all the selectors for the words.state.ts
+ */
 import { Rkp, Rks } from '@/recoil/index.keys'
 import { selector } from 'recoil'
 import { getWordsParamsState } from './words.state'
@@ -29,14 +32,14 @@ export const isFavoriteClickedSelector = selector<boolean>({
 export const selectedCustomizedTagsSelector = selector<string[]>({
   key: Rkp.Tags + Prk.SelectedCustomized + Rks.Selector,
   get: ({ get }) => {
-    return get(getWordsParamsState).tags || []
+    return get(getWordsParamsState).tags ?? []
   },
 })
 
 export const selectedLanguageTagsSelector = selector<GlobalLanguageCode[]>({
   key: Rkp.Tags + Prk.SelectedLanguage + Rks.Selector,
   get: ({ get }) => {
-    return get(getWordsParamsState).languageCodes || []
+    return get(getWordsParamsState).languageCodes ?? []
   },
 })
 


### PR DESCRIPTION
# Background
The previous name for `tags.selector.ts` contains the derived selector state of `words.state.ts` 

## TODOs
- [x] Fix file name to `words.state.ts` from  `tags.selector.ts`
- [x] Comment if any


## Related PRs
- _None_

## Checklists
- [x] One of the followings is handled
  - At least one or more issue is linked to this PR
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) has been replaced to the [issue](#issue) above, if no issue is related to this PR
- [x] Related PRs is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked
