### PR TITLE
Double Quote Bug for empty sample example

### DIFF
--- a/src/components/atom_word_card_parts/index.example.tsx
+++ b/src/components/atom_word_card_parts/index.example.tsx
@@ -17,7 +17,7 @@ const WordCardExamplePart: FC<Props> = ({ word }) => {
   const exampleTrimmed = word.example.trim()
   const linkExampleTrimmed = word.exampleLink.trim()
 
-  if (exampleTrimmed === `` && linkExampleTrimmed)
+  if (!exampleTrimmed && linkExampleTrimmed)
     return (
       <Link href={linkExampleTrimmed} target="_blank">
         Sample Example

--- a/src/components/atom_word_card_parts/index.example.tsx
+++ b/src/components/atom_word_card_parts/index.example.tsx
@@ -14,22 +14,24 @@ interface Props {
  *   If both exampleLink and example exist, return example with link (Handles 2 cases)
  */
 const WordCardExamplePart: FC<Props> = ({ word }) => {
-  const trimmedExample = word.example.trim()
-  const trimmedExampleLink = word.exampleLink.trim()
+  const exampleTrimmed = word.example.trim()
+  const linkExampleTrimmed = word.exampleLink.trim()
 
-  if (trimmedExample === `` && trimmedExampleLink)
+  if (exampleTrimmed === `` && linkExampleTrimmed)
     return (
-      <Link href={trimmedExampleLink} target="_blank">
+      <Link href={linkExampleTrimmed} target="_blank">
         Sample Example
       </Link>
     )
 
-  if (!trimmedExampleLink)
-    return <Typography>{`"${trimmedExample}"`}</Typography>
+  if (!linkExampleTrimmed && !exampleTrimmed) return null
+
+  if (!linkExampleTrimmed)
+    return <Typography>{`"${exampleTrimmed}"`}</Typography>
 
   return (
-    <Link href={trimmedExampleLink} target="_blank">
-      {trimmedExample}
+    <Link href={linkExampleTrimmed} target="_blank">
+      {exampleTrimmed}
     </Link>
   )
 }

--- a/src/components/atom_word_card_parts/index.example.tsx
+++ b/src/components/atom_word_card_parts/index.example.tsx
@@ -20,7 +20,7 @@ const WordCardExamplePart: FC<Props> = ({ word }) => {
   if (!exampleTrimmed && linkExampleTrimmed)
     return (
       <Link href={linkExampleTrimmed} target="_blank">
-        Sample Example
+        {linkExampleTrimmed}
       </Link>
     )
 


### PR DESCRIPTION
# Background
![image](https://github.com/ajktown/wordnote/assets/53258958/59b3b0db-9341-4d99-b6c9-77e6141a0550)

## TODOs 
- [x] Do not show double quotes if both `example` and `exampleLink` are not exist

## Related PRs
- _None_

## Checklists
- [x] One of the followings is handled
  - At least one or more issue is linked to this PR
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) has been replaced to the [issue](#issue) above, if no issue is related to this PR
- [x] Related PRs is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked
