### PR TITLE
Same Variant for Example & ExampleLink

### DIFF
--- a/src/components/atom_word_card_parts/index.example.tsx
+++ b/src/components/atom_word_card_parts/index.example.tsx
@@ -3,6 +3,7 @@ import { WordData } from '@/api/words/interfaces'
 import Link from 'next/link'
 import { Typography } from '@mui/material'
 
+const PRIVATE_VARIANT = `body2`
 interface Props {
   word: WordData
 }
@@ -20,18 +21,22 @@ const WordCardExamplePart: FC<Props> = ({ word }) => {
   if (!exampleTrimmed && linkExampleTrimmed)
     return (
       <Link href={linkExampleTrimmed} target="_blank">
-        {linkExampleTrimmed}
+        <Typography
+          variant={PRIVATE_VARIANT}
+        >{`${linkExampleTrimmed}`}</Typography>
       </Link>
     )
 
   if (!linkExampleTrimmed && !exampleTrimmed) return null
 
   if (!linkExampleTrimmed)
-    return <Typography>{`"${exampleTrimmed}"`}</Typography>
+    return (
+      <Typography variant={PRIVATE_VARIANT}>{`"${exampleTrimmed}"`}</Typography>
+    )
 
   return (
     <Link href={linkExampleTrimmed} target="_blank">
-      {exampleTrimmed}
+      <Typography variant={PRIVATE_VARIANT}>{`"${exampleTrimmed}"`}</Typography>
     </Link>
   )
 }


### PR DESCRIPTION
# Background
Font for example varies depending on the following condition of example
 - Both `example` and `exampleLink` is present
 - `example` is present but `exampleLink` is not
 - `example` is not present but `exampleLink` is
 - Both `example` and `exampleLink` is not present

## TODOs
- [x] Apply same variant for every conditions above

## Related PRs
- _None_

## Checklists
- [x] One of the followings is handled
  - At least one or more issue is linked to this PR
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) has been replaced to the [issue](#issue) above, if no issue is related to this PR
- [x] Related PRs is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked
