### PR TITLE
Preference with native language baseline code

### DIFF
--- a/src/api/preferences/index.interface.ts
+++ b/src/api/preferences/index.interface.ts
@@ -1,0 +1,7 @@
+import { GlobalLanguageCode } from '@/global.interface'
+import { DataBasics } from '../index.interface'
+
+export interface IPreference extends DataBasics {
+  id: string
+  nativeLanguages: GlobalLanguageCode[]
+}

--- a/src/components/atom_word_cards_frame_parts/index.preference-button.tsx
+++ b/src/components/atom_word_cards_frame_parts/index.preference-button.tsx
@@ -1,0 +1,25 @@
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+import { FC, Fragment } from 'react'
+import SettingsIcon from '@mui/icons-material/Settings'
+import PreferenceDialog from '../dialog_preference'
+import { useRecoilCallback } from 'recoil'
+import { isPreferenceDialogOpenedState } from '@/recoil/preferences/preference.state'
+
+const WordCardsFramePreferenceButtonPart: FC = () => {
+  const onClick = useRecoilCallback(({ set }) => () => {
+    set(isPreferenceDialogOpenedState, true)
+  })
+
+  return (
+    <Fragment>
+      <StyledIconButtonAtom
+        jsxElementButton={<SettingsIcon fontSize="small" />}
+        hoverMessage={{ title: `Preference` }}
+        onClick={onClick}
+      />
+      <PreferenceDialog />
+    </Fragment>
+  )
+}
+
+export default WordCardsFramePreferenceButtonPart

--- a/src/components/atom_word_cards_frame_parts/index.refresh-button.tsx
+++ b/src/components/atom_word_cards_frame_parts/index.refresh-button.tsx
@@ -3,7 +3,7 @@ import StyledCloudRefresher from '@/atoms/StyledCloudRefresher'
 import { useSemesters } from '@/hooks/semesters/use-semesters.hook'
 import { useWords } from '@/hooks/words/use-words.hook'
 
-const WordCardsFrameRefreshButton: FC = () => {
+const WordCardsFrameRefreshButtonPart: FC = () => {
   const [, getWords] = useWords()
   const getSemesters = useSemesters()
 
@@ -17,4 +17,4 @@ const WordCardsFrameRefreshButton: FC = () => {
   return <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />
 }
 
-export default WordCardsFrameRefreshButton
+export default WordCardsFrameRefreshButtonPart

--- a/src/components/atom_word_cards_frame_parts/index.surfing-button.tsx
+++ b/src/components/atom_word_cards_frame_parts/index.surfing-button.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/recoil/words/semesters.state'
 import { selectedSemesterSelector } from '@/recoil/words/words.selectors'
 
-const WordCardsFrameSurfingButton: FC = () => {
+const WordCardsFrameSurfingButtonPart: FC = () => {
   const [, onSemesterClick] = useSemesterClick()
 
   const onClick = useRecoilCallback(
@@ -47,4 +47,4 @@ const WordCardsFrameSurfingButton: FC = () => {
   )
 }
 
-export default WordCardsFrameSurfingButton
+export default WordCardsFrameSurfingButtonPart

--- a/src/components/dialog_preference/index.tsx
+++ b/src/components/dialog_preference/index.tsx
@@ -1,0 +1,52 @@
+import StyledTextButtonAtom from '@/atoms/StyledTextButton'
+import StyledDialog from '@/organisms/StyledDialog'
+import { isPreferenceDialogOpenedState } from '@/recoil/preferences/preference.state'
+import {
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+} from '@mui/material'
+import { FC } from 'react'
+import { useRecoilValue, useResetRecoilState } from 'recoil'
+
+const PreferenceDialog: FC = () => {
+  const isPreferenceDialogOpened = useRecoilValue(isPreferenceDialogOpenedState)
+  const resetPreferenceDialogOpenedState = useResetRecoilState(
+    isPreferenceDialogOpenedState,
+  )
+
+  if (!isPreferenceDialogOpened) return null
+
+  return (
+    <StyledDialog
+      visuals={{ maxWidth: `xs` }}
+      onClose={resetPreferenceDialogOpenedState}
+    >
+      <DialogTitle>{`Select your native languages`}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          {`Any changes will be automatically saved to the cloud`}
+        </DialogContentText>
+        <FormGroup>
+          <FormControlLabel control={<Checkbox />} label="English" />
+          <FormControlLabel control={<Checkbox />} label="Chinese" />
+          <FormControlLabel control={<Checkbox />} label="Japanese" />
+          <FormControlLabel control={<Checkbox />} label="Korean" />
+        </FormGroup>
+      </DialogContent>
+      <DialogActions>
+        <StyledTextButtonAtom
+          variant="text"
+          title="Close"
+          onClick={resetPreferenceDialogOpenedState}
+        />
+      </DialogActions>
+    </StyledDialog>
+  )
+}
+
+export default PreferenceDialog

--- a/src/components/organism_word_card_frame/index.tsx
+++ b/src/components/organism_word_card_frame/index.tsx
@@ -8,6 +8,7 @@ import { WordCardFrameStyle } from './index.style'
 import WordCardDialog from '../molecule_word_card/index.dialog'
 import TagButtonChunkSemesters from '../molecule_tag_button_chunk/index.semesters'
 import TagButtonChunkDetailed from '../molecule_tag_button_chunk/index.detailed'
+import WordCardsFramePreferenceButtonPart from '../atom_word_cards_frame_parts/index.preference-button'
 
 const WordCardFrame: FC = () => {
   return (
@@ -18,6 +19,7 @@ const WordCardFrame: FC = () => {
           <Box flexGrow={1} />
           <WordCardsSurfingButton />
           <WordCardsFrameRefreshButton />
+          <WordCardsFramePreferenceButtonPart />
         </Stack>
         <Stack alignItems={`center`} spacing={0.35}>
           <TagButtonChunkSemesters />

--- a/src/components/organism_word_card_frame/index.tsx
+++ b/src/components/organism_word_card_frame/index.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react'
 import { Stack, Box } from '@mui/material'
 import NewWordBox from '../molecule_new_word_box'
-import WordCardsFrameRefreshButton from '../atom_word_cards_frame_refresh_button'
-import WordCardsSurfingButton from '../atom_word_cards_frame_surfing_button'
+import WordCardsFrameRefreshButtonPart from '../atom_word_cards_frame_parts/index.refresh-button'
+import WordCardsFrameSurfingButtonPart from '../atom_word_cards_frame_parts/index.surfing-button'
 import WordCardsChunk from '../organism_word_card_chunk'
 import { WordCardFrameStyle } from './index.style'
 import WordCardDialog from '../molecule_word_card/index.dialog'
@@ -15,10 +15,10 @@ const WordCardFrame: FC = () => {
     <Stack width="100%" alignItems="center">
       <Stack {...WordCardFrameStyle}>
         {/* Header */}
-        <Stack direction="row" spacing={0.5}>
+        <Stack direction="row" spacing={0.7}>
           <Box flexGrow={1} />
-          <WordCardsSurfingButton />
-          <WordCardsFrameRefreshButton />
+          <WordCardsFrameSurfingButtonPart />
+          <WordCardsFrameRefreshButtonPart />
           <WordCardsFramePreferenceButtonPart />
         </Stack>
         <Stack alignItems={`center`} spacing={0.35}>

--- a/src/hooks/app/use-on-sign-out-app.hook.ts
+++ b/src/hooks/app/use-on-sign-out-app.hook.ts
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { PageConst } from '@/constants/pages.constant'
 import { wordIdsState } from '@/recoil/words/words.state'
 import { postSignOut } from '@/api/auth/post-sign-out.api'
+import { preferenceState } from '@/recoil/preferences/preference.state'
 
 export const useOnSignOutApp = () => {
   const router = useRouter()
@@ -12,6 +13,7 @@ export const useOnSignOutApp = () => {
       async () => {
         await postSignOut()
         reset(wordIdsState)
+        reset(preferenceState)
         router.push(PageConst.Welcome)
         // TODO: Should set a snackbar for a reason.
       },

--- a/src/recoil/index.keys.ts
+++ b/src/recoil/index.keys.ts
@@ -2,6 +2,7 @@
 export enum Rkp {
   App = `App`,
   Words = `Words`,
+  Preferences = `Preferences`,
   Tags = `Tags`,
   Semesters = `Semesters`,
   SearchInput = `SearchInput`,

--- a/src/recoil/preferences/preference.state.ts
+++ b/src/recoil/preferences/preference.state.ts
@@ -1,0 +1,23 @@
+import { atom } from 'recoil'
+import { Rkp } from '@/recoil/index.keys'
+import { IPreference } from '@/api/preferences/index.interface'
+
+/** Private Recoil Key */
+enum Prk {
+  IsPreferenceDialogOpened = `IsPreferenceDialogOpened`,
+}
+
+/** preferenceState holds signed in user's preference data.
+ * If not signed in, it is null.
+ * If signed in but has no data yet, it can be still null and therefore should be handled.
+ */
+export const preferenceState = atom<null | IPreference>({
+  key: Rkp.Preferences,
+  default: null,
+})
+
+/** IsPreferenceDialogOpened represents if dialog is opened */
+export const isPreferenceDialogOpenedState = atom<boolean>({
+  key: Rkp.Preferences + Prk.IsPreferenceDialogOpened,
+  default: false,
+})


### PR DESCRIPTION
# Background 
As more dictionaries are introduced in https://github.com/ajktown/wordnote/pull/97, https://github.com/ajktown/wordnote/pull/88 and https://github.com/ajktown/wordnote/pull/69, some of them are not needed depend on the user's native tongue.

Although API will be involved with the preference stored on the cloud, we first develop a simple dialog that holds the native languages.

## TODOs
- [x] Make a preference state
- [x] Make a dialog boilerplate to change the preference
- [x] Refactor with new suffix `Part`

## Related PRs
- _None_

## Checklists
- [x] One of the followings is handled
  - At least one or more issue are linked to this PR under `development`
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) is directly copied above the `Related PRs`
- [x] `Related PRs` is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked
