### PR TITLE
Dummy data for preference state

### DIFF
--- a/src/recoil/preferences/preference.state.ts
+++ b/src/recoil/preferences/preference.state.ts
@@ -13,7 +13,11 @@ enum Prk {
  */
 export const preferenceState = atom<null | IPreference>({
   key: Rkp.Preferences,
-  default: null,
+  default: {
+    id: `abc`,
+    nativeLanguages: [`ja`],
+    createdAt: `2021-01-01T00:00:00.000Z`,
+  },
 })
 
 /** IsPreferenceDialogOpened represents if dialog is opened */


### PR DESCRIPTION
# Background
I should add dummy data for preference so that @akanex115  can develop a bit easier.

## TODOs
- [x] Add dummy data

## Checklists
- [x] One of the followings is handled
  - At least one or more issue are linked to this PR under `development`
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) is directly copied above the `Related PRs`
- [x] `Related PRs` is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked
