### PR TITLE
Dev Token in Welcome Page

### DIFF
--- a/src/pages/welcome/index.tsx
+++ b/src/pages/welcome/index.tsx
@@ -1,3 +1,4 @@
+import ContinueWithDeveloperToken from '@/components/atom_continue_with/index.dev'
 import { PageConst } from '@/constants/pages.constant'
 import { useGoogleOneTabSignIn } from '@/hooks/auth/use-google-one-tab-sign-in.hook'
 import StyledCentered from '@/organisms/StyledCentered'
@@ -21,6 +22,7 @@ const WelcomePage: FC = () => {
     <StyledCentered>
       <h3>{`Welcome to AJK Town's Wordnote.`}</h3>
       <h3>{`Sign in with your AJK Town account to continue.`}</h3>
+      <ContinueWithDeveloperToken />
       <Button onClick={onClickSignIn}> {`Sign in`}</Button>
       <Button onClick={onClickSignUp}> {`Sign up`}</Button>
       <a style={{ fontStyle: `italic` }}>


### PR DESCRIPTION
# Background
We want to let the developers sign in right away with dev token under development env.
<img width="878" alt="image" src="https://github.com/ajktown/wordnote/assets/53258958/a243e1bf-377c-4ee3-b57d-226f8f3b5c25">

# TODOs
- [x] Implement in a way that dev token sign in is available same as the sign in page shows

## Related PRs
- _None_

## Checklist (Developers)
- [x] One of the followings is handled
  - At least one or more issue are linked to this PR under `development`
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) is directly copied above the `Related PRs`
- [x] `Related PRs` is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Every item on the checklist has been addressed accordingly
