### PR TITLE
On Click Refresh Performance

### DIFF
--- a/src/components/atom_word_cards_frame_parts/index.refresh-button.tsx
+++ b/src/components/atom_word_cards_frame_parts/index.refresh-button.tsx
@@ -12,14 +12,21 @@ const WordCardsFrameRefreshButtonPart: FC = () => {
   const getPreference = usePreference()
   const selectedSemester = useRecoilValue(selectedSemesterSelector)
 
-  const onClickRefresh = useCallback(async () => {
+  /**
+   * Sync words with the API Server. If selectedSemester is undefined,
+   * the API will understand and return the latest semester.
+   */
+  const onGetWordsSync = useCallback(async () => {
     const semesters = await getSemesters()
-    if (!semesters.latestSemesterCode) return
+    if (!semesters.latestSemesterCode) return // User has never created word even once.
 
     await getWords({ semester: selectedSemester })
+  }, [selectedSemester, getSemesters, getWords])
 
-    await getPreference()
-  }, [getWords, getSemesters, getPreference, selectedSemester])
+  const onClickRefresh = useCallback(async () => {
+    // run all together
+    await Promise.all([onGetWordsSync(), getPreference()])
+  }, [onGetWordsSync, getPreference])
 
   return <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />
 }

--- a/src/components/atom_word_cards_frame_parts/index.refresh-button.tsx
+++ b/src/components/atom_word_cards_frame_parts/index.refresh-button.tsx
@@ -1,32 +1,16 @@
 import { FC, useCallback } from 'react'
 import StyledCloudRefresher from '@/atoms/StyledCloudRefresher'
-import { useSemesters } from '@/hooks/semesters/use-semesters.hook'
-import { useWords } from '@/hooks/words/use-words.hook'
 import { usePreference } from '@/hooks/preference/use-preference.hook'
-import { useRecoilValue } from 'recoil'
-import { selectedSemesterSelector } from '@/recoil/words/words.selectors'
+import { useWordsWithSemesters } from '@/hooks/words/use-words-with-semesters.hook'
 
 const WordCardsFrameRefreshButtonPart: FC = () => {
-  const [, getWords] = useWords()
-  const getSemesters = useSemesters()
-  const getPreference = usePreference()
-  const selectedSemester = useRecoilValue(selectedSemesterSelector)
-
-  /**
-   * Sync words with the API Server. If selectedSemester is undefined,
-   * the API will understand and return the latest semester.
-   */
-  const onGetWordsSync = useCallback(async () => {
-    const semesters = await getSemesters()
-    if (!semesters.latestSemesterCode) return // User has never created word even once.
-
-    await getWords({ semester: selectedSemester })
-  }, [selectedSemester, getSemesters, getWords])
+  const onGetPreference = usePreference()
+  const onGetWordsWithSemesters = useWordsWithSemesters()
 
   const onClickRefresh = useCallback(async () => {
     // run all together
-    await Promise.all([onGetWordsSync(), getPreference()])
-  }, [onGetWordsSync, getPreference])
+    await Promise.all([onGetWordsWithSemesters(), onGetPreference()])
+  }, [onGetWordsWithSemesters, onGetPreference])
 
   return <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />
 }

--- a/src/hooks/preference/use-preference.hook.ts
+++ b/src/hooks/preference/use-preference.hook.ts
@@ -2,6 +2,9 @@ import { useRecoilCallback } from 'recoil'
 import { preferenceState } from '@/recoil/preferences/preference.state'
 import { getPreferenceApi } from '@/api/preferences/get-preferences.api'
 
+/** Gets the latest preference data of the signed end user
+ * from the server and updates the preference state.
+ */
 export const usePreference = () => {
   const onClick = useRecoilCallback(
     ({ set }) =>

--- a/src/hooks/words/use-words-with-semesters.hook.ts
+++ b/src/hooks/words/use-words-with-semesters.hook.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react'
+import { useRecoilValue } from 'recoil'
+import { useWords } from './use-words.hook'
+import { useSemesters } from '../semesters/use-semesters.hook'
+import { selectedSemesterSelector } from '@/recoil/words/words.selectors'
+
+/**
+ * Sync words with the API Server. If selectedSemester is undefined,
+ * it is considered as the end user has never created a word before.
+ * the API will understand and return the latest semester.
+ */
+export const useWordsWithSemesters = () => {
+  const selectedSemester = useRecoilValue(selectedSemesterSelector)
+
+  const [, onGetWords] = useWords()
+  const onGetSemesters = useSemesters()
+
+  const onGetWordsWithSemesters = useCallback(async () => {
+    const semesters = await onGetSemesters()
+    if (!semesters.latestSemesterCode) return // User has never created word even once.
+
+    await onGetWords({ semester: selectedSemester })
+  }, [selectedSemester, onGetSemesters, onGetWords])
+
+  return onGetWordsWithSemesters
+}


### PR DESCRIPTION
# Background 
There was a bug in refresh defined in issue https://github.com/ajktown/wordnote/issues/117 and was handled in the pr https://github.com/ajktown/wordnote/pull/119.
The pr however has decreased the performance due to the lack of simultaneous request to the API.

## TODOs
- [x] Fix the flow
- [X] Modify the doc for the changed flow
  - Make sure the simultaneous run is well documented in the activity diagram
  - Create an issue that handles this in https://github.com/ajktown/docs/issues/36

## Related PRs
- _None_

## Checklist (Developers)
- [x] `Related PRs` is correctly modified, if it is not `None`
- [x] One of the followings is handled
  - At least one or more issue are linked to this PR under `development`
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) is directly copied above the `Related PRs`
    - You can directly copy background with issue from the samed/different repository.
  - One of the related PRs is linked to the issue under `development`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked
- [x] Final Operation Check is done

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Every item on the checklist has been addressed accordingly
