### PR TITLE
Days Ago Unselects Favorite

### DIFF
--- a/src/components/atom_tag_button/index.days_ago.tsx
+++ b/src/components/atom_tag_button/index.days_ago.tsx
@@ -44,6 +44,7 @@ const TagButtonDaysAgo: FC<Props> = ({ daysAgo }) => {
   const onClick = useCallback(async () => {
     try {
       await getWords({
+        isFavorite: undefined,
         daysAgo: daysAgo === selectedDaysAgo ? undefined : daysAgo,
       })
     } catch {}


### PR DESCRIPTION
# Background
https://github.com/ajktown/wordnote/issues/131

## TODOs
- [x] Once DaysAgo chip is clicked, the favorite is unchecked.

## Related PRs
- _None_

## Checklist (Developers)
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] `Related PRs` is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
