### PR TITLE
Try Catch for Sign Out Flow

### DIFF
--- a/src/hooks/app/use-on-sign-out-app.hook.ts
+++ b/src/hooks/app/use-on-sign-out-app.hook.ts
@@ -11,11 +11,15 @@ export const useOnSignOutApp = () => {
   const onSignOutApp = useRecoilCallback(
     ({ reset }) =>
       async () => {
-        await postSignOut()
-        reset(wordIdsState)
-        reset(preferenceState)
-        router.push(PageConst.Welcome)
-        // TODO: Should set a snackbar for a reason.
+        try {
+          await postSignOut()
+        } finally {
+          reset(wordIdsState)
+          reset(preferenceState)
+          router.push(PageConst.Welcome)
+
+          // TODO: Should set a snackbar for a reason.
+        }
       },
     [router],
   )


### PR DESCRIPTION
# Background
The current logic of the sign out flow won't reset state, if the api server does not respond properly

## TODOs
- [x] Use `Try .. catch` for the postSignOut

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
