### PR TITLE
Top of Page Button

### DIFF
--- a/src/components/atom_top_of_page_button/index.tsx
+++ b/src/components/atom_top_of_page_button/index.tsx
@@ -1,0 +1,22 @@
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+import { FC, useCallback } from 'react'
+import TopOfPageIcon from '@mui/icons-material/KeyboardArrowUp'
+
+/**
+ * Goes to the top of the page of the end user's browser.
+ * Use-cases
+ * 1. When the end user wants to go to the top of the page, at the end of the Wordcard list page.
+ */
+export const TopOfPageButton: FC = () => {
+  const onClick = useCallback(() => {
+    window.scrollTo(0, 0)
+  }, [])
+
+  return (
+    <StyledIconButtonAtom
+      jsxElementButton={<TopOfPageIcon />}
+      onClick={onClick}
+      hoverMessage={{ title: `Top of page` }}
+    />
+  )
+}

--- a/src/components/organism_word_card_chunk/index.tsx
+++ b/src/components/organism_word_card_chunk/index.tsx
@@ -8,6 +8,7 @@ import StyledSuspense from '@/organisms/StyledSuspense'
 import WordCardsChunkNoWordsFound from './index.no_words_found'
 import WordCardChunkSearchFound from './index.search_found'
 import WordIdsPagination from '../atom_word_ids_pagination'
+import { TopOfPageButton } from '../atom_top_of_page_button'
 
 const WordCardsChunk: FC = () => {
   const searchInput = useRecoilValue(searchInputState)
@@ -25,6 +26,7 @@ const WordCardsChunk: FC = () => {
         <WordCard key={wordId} wordId={wordId} />
       ))}
       <WordIdsPagination />
+      <TopOfPageButton />
     </StyledSuspense>
   )
 }


### PR DESCRIPTION
# Background
It is bothersome to go to the top of the page at the bottom of Wordcard frame, if you have many words.

## TODOs
- [x] Implement a button that goes to the top of the page
  - ![Screenshot 2024-01-01 at 10 04 45](https://github.com/ajktown/wordnote/assets/53258958/7d5c972d-e623-4261-b980-bbd7f4003b2e)


## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
