### PR TITLE
Review mode with meaning only

### DIFF
--- a/src/components/atom_word_card_parts/index.example.tsx
+++ b/src/components/atom_word_card_parts/index.example.tsx
@@ -6,6 +6,7 @@ import { Typography } from '@mui/material'
 const PRIVATE_VARIANT = `body2`
 interface Props {
   word: WordData
+  reviewMode?: boolean // if review mode, it shows "???"
 }
 /**
  * @returns
@@ -14,9 +15,12 @@ interface Props {
  *   If exampleLink exists, but example does not exist, return Sample Example (Handles 2 cases)
  *   If both exampleLink and example exist, return example with link (Handles 2 cases)
  */
-const WordCardExamplePart: FC<Props> = ({ word }) => {
+const WordCardExamplePart: FC<Props> = ({ word, reviewMode }) => {
   const exampleTrimmed = word.example.trim()
   const linkExampleTrimmed = word.exampleLink.trim()
+
+  if (reviewMode)
+    return <Typography variant={PRIVATE_VARIANT}>{`???`}</Typography>
 
   if (!exampleTrimmed && linkExampleTrimmed)
     return (

--- a/src/components/atom_word_cards_frame_parts/index.review-mode.tsx
+++ b/src/components/atom_word_cards_frame_parts/index.review-mode.tsx
@@ -19,21 +19,24 @@ const WordCardsFrameReviewModePart: FC = () => {
       },
     [isReviewMode],
   )
-  const hoverMessage = useMemo(() => {
-    return {
+  const hoverMessage = useMemo(
+    () => ({
       title: isReviewMode
         ? `Show everything`
         : `Hide everything except meanings`,
-    }
-  }, [isReviewMode])
+    }),
+    [isReviewMode],
+  )
 
-  const jsxElementButton = useMemo(() => {
-    return isReviewMode ? (
-      <ReviewModeToOn fontSize="small" />
-    ) : (
-      <ReviewModeToOff fontSize="small" />
-    )
-  }, [isReviewMode])
+  const jsxElementButton = useMemo(
+    () =>
+      isReviewMode ? (
+        <ReviewModeToOn fontSize="small" />
+      ) : (
+        <ReviewModeToOff fontSize="small" />
+      ),
+    [isReviewMode],
+  )
 
   return (
     <StyledIconButtonAtom

--- a/src/components/atom_word_cards_frame_parts/index.review-mode.tsx
+++ b/src/components/atom_word_cards_frame_parts/index.review-mode.tsx
@@ -19,9 +19,14 @@ const WordCardsFrameReviewModePart: FC = () => {
       },
     [isReviewMode],
   )
-  const hoverMessage = {
-    title: isReviewMode ? `Show everything` : `Hide everything except meanings`,
-  }
+  const hoverMessage = useMemo(() => {
+    return {
+      title: isReviewMode
+        ? `Show everything`
+        : `Hide everything except meanings`,
+    }
+  }, [isReviewMode])
+
   const jsxElementButton = useMemo(() => {
     return isReviewMode ? (
       <ReviewModeToOn fontSize="small" />

--- a/src/components/atom_word_cards_frame_parts/index.review-mode.tsx
+++ b/src/components/atom_word_cards_frame_parts/index.review-mode.tsx
@@ -1,0 +1,42 @@
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+import { FC, useMemo } from 'react'
+import { useRecoilCallback, useRecoilValue } from 'recoil'
+import ReviewModeToOff from '@mui/icons-material/VisibilityOff'
+import ReviewModeToOn from '@mui/icons-material/Visibility'
+import { isReviewModeState } from '@/recoil/preferences/preference.state'
+/**
+ * When you click it, the Wordnote becomes a review mode.
+ * Use-cases
+ * 1. When user wants to test himself/herself.
+ */
+const WordCardsFrameReviewModePart: FC = () => {
+  const isReviewMode = useRecoilValue(isReviewModeState)
+
+  const onClick = useRecoilCallback(
+    ({ set }) =>
+      async () => {
+        set(isReviewModeState, !isReviewMode)
+      },
+    [isReviewMode],
+  )
+  const hoverMessage = {
+    title: isReviewMode ? `Show everything` : `Hide everything except meanings`,
+  }
+  const jsxElementButton = useMemo(() => {
+    return isReviewMode ? (
+      <ReviewModeToOn fontSize="small" />
+    ) : (
+      <ReviewModeToOff fontSize="small" />
+    )
+  }, [isReviewMode])
+
+  return (
+    <StyledIconButtonAtom
+      onClick={onClick}
+      jsxElementButton={jsxElementButton}
+      hoverMessage={hoverMessage}
+    />
+  )
+}
+
+export default WordCardsFrameReviewModePart

--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -1,0 +1,39 @@
+import { FC } from 'react'
+import { Card, CardActions, CardContent, Typography } from '@mui/material'
+import WordCardFavoriteIcon from '../atom_word_card_favorite_icon'
+import StyledSuspense from '@/organisms/StyledSuspense'
+import { WordData } from '@/api/words/interfaces'
+import TagButtonChunk from '../molecule_tag_button_chunk'
+import WordCardExamplePart from '../atom_word_card_parts/index.example'
+
+interface Props {
+  word: WordData
+}
+
+const WordCardReviewMode: FC<Props> = ({ word }) => {
+  return (
+    <StyledSuspense>
+      <Card style={{ width: `100%`, borderRadius: 9 }}>
+        <CardContent>
+          <Typography variant="h5" component="div">
+            {`???`}
+          </Typography>
+          <Typography sx={{ mb: 1.5 }} color="text.secondary">
+            {`???`}
+          </Typography>
+          <Typography variant="body2">
+            {word.definition}
+            <br />
+          </Typography>
+          <WordCardExamplePart word={word} reviewMode />
+        </CardContent>
+        <CardActions>
+          <WordCardFavoriteIcon wordId={word.id} />
+          <TagButtonChunk wordId={word.id} />
+        </CardActions>
+      </Card>
+    </StyledSuspense>
+  )
+}
+
+export default WordCardReviewMode

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -17,7 +17,11 @@ import DictLinkButtonChunk from '../molecule_dict_link_button_chunk'
 import WordCardExamplePart from '../atom_word_card_parts/index.example'
 import WordCardArchiveButtonPart from '../atom_word_card_parts/index.archive-button'
 import WordCardUnarchiveButtonPart from '../atom_word_card_parts/index.unarchive-button'
-import { isShowingArchivedState } from '@/recoil/preferences/preference.state'
+import {
+  isReviewModeState,
+  isShowingArchivedState,
+} from '@/recoil/preferences/preference.state'
+import WordCardReviewMode from './index.review_mode'
 
 interface Props {
   wordId: string
@@ -29,6 +33,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
   const setSelectedWordIdForDialog = useSetRecoilState(
     selectedWordIdForDialogState,
   )
+  const isReviewMode = useRecoilValue(isReviewModeState)
 
   const handleClickWordCard = useCallback(() => {
     !editingMode && setSelectedWordIdForDialog(wordId)
@@ -40,6 +45,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
   if (!word.isArchived && isShowingArchived) return null
   if (word.isDeleted) return <WordCardDeleted wordId={wordId} />
   if (editingMode) return <WordCardEditingMode wordId={wordId} />
+  if (isReviewMode) return <WordCardReviewMode word={word} />
 
   return (
     <StyledSuspense>

--- a/src/components/organism_word_card_frame/index.tsx
+++ b/src/components/organism_word_card_frame/index.tsx
@@ -11,6 +11,7 @@ import TagButtonChunkDetailed from '../molecule_tag_button_chunk/index.detailed'
 import WordCardsFramePreferenceButtonPart from '../atom_word_cards_frame_parts/index.preference-button'
 import WordCardsFrameArchiveSwitchPart from '../atom_word_cards_frame_parts/index.archive-switch'
 import WordCardsFrameArchiveModePart from '../atom_word_cards_frame_parts/index.archive-mode'
+import WordCardsFrameReviewModePart from '../atom_word_cards_frame_parts/index.review-mode'
 
 const WordCardFrame: FC = () => {
   return (
@@ -19,6 +20,7 @@ const WordCardFrame: FC = () => {
         {/* Header */}
         <Stack direction="row" spacing={0.7} alignItems="center">
           <Box flexGrow={1} />
+          <WordCardsFrameReviewModePart />
           <WordCardsFrameArchiveSwitchPart />
           <WordCardsFrameSurfingButtonPart />
           <WordCardsFrameRefreshButtonPart />

--- a/src/hooks/words/use-put-word-tag-added.hook.ts
+++ b/src/hooks/words/use-put-word-tag-added.hook.ts
@@ -32,10 +32,12 @@ export const usePutWordTagAdded = (
           const semesterDetails = await snapshot.getPromise(
             semesterDetailsFamily(wordData.semester),
           )
-          set(semesterDetailsFamily(wordData.semester), {
-            ...semesterDetails,
-            tags: Array.from(new Set([...semesterDetails.tags, newTagName])),
-          })
+          if (semesterDetails) {
+            set(semesterDetailsFamily(wordData.semester), {
+              ...semesterDetails,
+              tags: Array.from(new Set([...semesterDetails.tags, newTagName])),
+            })
+          }
 
           if (callback) callback()
         } finally {

--- a/src/recoil/preferences/preference.state.ts
+++ b/src/recoil/preferences/preference.state.ts
@@ -30,6 +30,7 @@ export const isShowingArchivedState = atom<boolean>({
   default: false,
 })
 
+/** isReviewModeState represents if end user is using ReviewMode */
 export const isReviewModeState = atom<boolean>({
   key: Rkp.Preferences + Prk.IsReviewModeState,
   default: false,

--- a/src/recoil/preferences/preference.state.ts
+++ b/src/recoil/preferences/preference.state.ts
@@ -6,6 +6,7 @@ import { IPreference } from '@/api/preferences/index.interface'
 enum Prk {
   IsPreferenceDialogOpened = `IsPreferenceDialogOpened`,
   IsShowingArchivedState = `IsShowingArchivedState`,
+  isReviewModeState = `isReviewModeState`,
 }
 
 /** preferenceState holds signed in user's preference data.
@@ -23,7 +24,13 @@ export const isPreferenceDialogOpenedState = atom<boolean>({
   default: false,
 })
 
+/** isShowingArchivedState represents if end user wants to see the archived words only or not */
 export const isShowingArchivedState = atom<boolean>({
   key: Rkp.Preferences + Prk.IsShowingArchivedState,
+  default: false,
+})
+
+export const isReviewModeState = atom<boolean>({
+  key: Rkp.Preferences + Prk.isReviewModeState,
   default: false,
 })

--- a/src/recoil/preferences/preference.state.ts
+++ b/src/recoil/preferences/preference.state.ts
@@ -6,7 +6,7 @@ import { IPreference } from '@/api/preferences/index.interface'
 enum Prk {
   IsPreferenceDialogOpened = `IsPreferenceDialogOpened`,
   IsShowingArchivedState = `IsShowingArchivedState`,
-  isReviewModeState = `isReviewModeState`,
+  IsReviewModeState = `IsReviewModeState`,
 }
 
 /** preferenceState holds signed in user's preference data.
@@ -31,6 +31,6 @@ export const isShowingArchivedState = atom<boolean>({
 })
 
 export const isReviewModeState = atom<boolean>({
-  key: Rkp.Preferences + Prk.isReviewModeState,
+  key: Rkp.Preferences + Prk.IsReviewModeState,
   default: false,
 })


### PR DESCRIPTION
# Background
By clicking the red button, you can review your Wordcard orange
![image](https://github.com/ajktown/wordnote/assets/53258958/ff03e2ba-291f-4029-baf6-ea793e314424)
as
![image](https://github.com/ajktown/wordnote/assets/53258958/1452d9ee-6bd8-40d6-98ac-fd41c628a7f5)


## TODOs
- [x] Implement very simple review mode showing only the definition

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
