### PR TITLE
Review mode peek feature

### DIFF
--- a/src/atoms/StyledVisibility.tsx
+++ b/src/atoms/StyledVisibility.tsx
@@ -1,0 +1,45 @@
+import { FC, useMemo } from 'react'
+import StyledIconButtonAtom from './StyledIconButton'
+import VisibilityToOff from '@mui/icons-material/VisibilityOff'
+import VisibilityToOn from '@mui/icons-material/Visibility'
+
+interface Props {
+  isVisible: boolean
+  visibleHoverMessage?: string // message when visible
+  invisibleHoverMessage?: string // message when not visible
+  onClick: () => any
+}
+
+/**
+ * StyledVisibilityAtom is a simple button to shows either visible or not visible based on given props.
+ */
+const StyledVisibilityAtom: FC<Props> = ({
+  isVisible,
+  visibleHoverMessage,
+  invisibleHoverMessage,
+  onClick,
+}) => {
+  const jsxElementButton = useMemo(
+    () =>
+      isVisible ? (
+        <VisibilityToOn fontSize="small" />
+      ) : (
+        <VisibilityToOff fontSize="small" />
+      ),
+    [isVisible],
+  )
+
+  return (
+    <StyledIconButtonAtom
+      onClick={onClick}
+      jsxElementButton={jsxElementButton}
+      hoverMessage={{
+        title: isVisible
+          ? visibleHoverMessage ?? ``
+          : invisibleHoverMessage ?? ``,
+      }}
+    />
+  )
+}
+
+export default StyledVisibilityAtom

--- a/src/components/atom_word_cards_frame_parts/index.review-mode.tsx
+++ b/src/components/atom_word_cards_frame_parts/index.review-mode.tsx
@@ -1,9 +1,7 @@
-import StyledIconButtonAtom from '@/atoms/StyledIconButton'
-import { FC, useMemo } from 'react'
+import { FC } from 'react'
 import { useRecoilCallback, useRecoilValue } from 'recoil'
-import ReviewModeToOff from '@mui/icons-material/VisibilityOff'
-import ReviewModeToOn from '@mui/icons-material/Visibility'
 import { isReviewModeState } from '@/recoil/preferences/preference.state'
+import StyledVisibilityAtom from '@/atoms/StyledVisibility'
 /**
  * When you click it, the Wordnote becomes a review mode.
  * Use-cases
@@ -19,30 +17,13 @@ const WordCardsFrameReviewModePart: FC = () => {
       },
     [isReviewMode],
   )
-  const hoverMessage = useMemo(
-    () => ({
-      title: isReviewMode
-        ? `Show everything`
-        : `Hide everything except meanings`,
-    }),
-    [isReviewMode],
-  )
-
-  const jsxElementButton = useMemo(
-    () =>
-      isReviewMode ? (
-        <ReviewModeToOn fontSize="small" />
-      ) : (
-        <ReviewModeToOff fontSize="small" />
-      ),
-    [isReviewMode],
-  )
 
   return (
-    <StyledIconButtonAtom
+    <StyledVisibilityAtom
+      isVisible={isReviewMode}
       onClick={onClick}
-      jsxElementButton={jsxElementButton}
-      hoverMessage={hoverMessage}
+      visibleHoverMessage={`Show everything`}
+      invisibleHoverMessage={`Hide everything except meanings`}
     />
   )
 }

--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -1,34 +1,42 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import { Card, CardActions, CardContent, Typography } from '@mui/material'
 import WordCardFavoriteIcon from '../atom_word_card_favorite_icon'
 import StyledSuspense from '@/organisms/StyledSuspense'
 import { WordData } from '@/api/words/interfaces'
 import TagButtonChunk from '../molecule_tag_button_chunk'
 import WordCardExamplePart from '../atom_word_card_parts/index.example'
+import StyledVisibilityAtom from '@/atoms/StyledVisibility'
 
 interface Props {
   word: WordData
 }
 
 const WordCardReviewMode: FC<Props> = ({ word }) => {
+  const [isPeakMode, setPeakMode] = useState(false)
+
   return (
     <StyledSuspense>
       <Card style={{ width: `100%`, borderRadius: 9 }}>
         <CardContent>
           <Typography variant="h5" component="div">
-            {`???`}
+            {isPeakMode ? word.term : `???`}
           </Typography>
           <Typography sx={{ mb: 1.5 }} color="text.secondary">
-            {`???`}
+            {isPeakMode ? word.pronunciation : `???`}
           </Typography>
           <Typography variant="body2">
             {word.definition}
             <br />
           </Typography>
-          <WordCardExamplePart word={word} reviewMode />
+          <WordCardExamplePart word={word} reviewMode={!isPeakMode} />
         </CardContent>
         <CardActions>
           <WordCardFavoriteIcon wordId={word.id} />
+          <StyledVisibilityAtom
+            isVisible={!isPeakMode}
+            onClick={() => setPeakMode(!isPeakMode)}
+            visibleHoverMessage={`Peak this Wordcard`}
+          />
           <TagButtonChunk wordId={word.id} />
         </CardActions>
       </Card>

--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -12,30 +12,30 @@ interface Props {
 }
 
 const WordCardReviewMode: FC<Props> = ({ word }) => {
-  const [isPeakMode, setPeakMode] = useState(false)
+  const [isPeekMode, setPeekMode] = useState(false)
 
   return (
     <StyledSuspense>
       <Card style={{ width: `100%`, borderRadius: 9 }}>
         <CardContent>
           <Typography variant="h5" component="div">
-            {isPeakMode ? word.term : `???`}
+            {isPeekMode ? word.term : `???`}
           </Typography>
           <Typography sx={{ mb: 1.5 }} color="text.secondary">
-            {isPeakMode ? word.pronunciation : `???`}
+            {isPeekMode ? word.pronunciation : `???`}
           </Typography>
           <Typography variant="body2">
             {word.definition}
             <br />
           </Typography>
-          <WordCardExamplePart word={word} reviewMode={!isPeakMode} />
+          <WordCardExamplePart word={word} reviewMode={!isPeekMode} />
         </CardContent>
         <CardActions>
           <WordCardFavoriteIcon wordId={word.id} />
           <StyledVisibilityAtom
-            isVisible={!isPeakMode}
-            onClick={() => setPeakMode(!isPeakMode)}
-            visibleHoverMessage={`Peak this Wordcard`}
+            isVisible={!isPeekMode}
+            onClick={() => setPeekMode(!isPeekMode)}
+            visibleHoverMessage={`Peek this Wordcard`}
           />
           <TagButtonChunk wordId={word.id} />
         </CardActions>


### PR DESCRIPTION
# Background
Review mode was introduced in #142 but has found out that peek mode would be great to review even faster as following:
![image](https://github.com/ajktown/wordnote/assets/53258958/5bcd3e75-fde1-445a-b223-d4d98719518a)


## TODOs
- [X] Feature for `peek the wordcard`

## Checklist (Developers)
- [X] Make this PR as a draft first
- [X] Title is checked
- [X] Background & TODOs are filled
- [X] Assignee is set
- [X] Labels are set
- [X] Project is created & linked, if multiple PRs are associated to this PR
- [X] Appropriate issue(s) is(are) linked to this PR under `development`
- [X] `yarn inspect` is run
- [X] `TODOs` are handled and checked
- [X] Final Operation Check is done
- [X] Make this PR as an open PR

## Checklist (Reviewers)
- [X] Check if there are any other missing TODOs that are not yet listed
- [ ] Review Code
- [X] Every item on the checklist has been addressed accordingly
- [X] If `development` is associated to this PR, you must check if every TODOs are handled
