### PR TITLE
Refresh Button Bug with Latest Semester Not Automatically Selected

### DIFF
--- a/src/hooks/words/use-words-with-semesters.hook.ts
+++ b/src/hooks/words/use-words-with-semesters.hook.ts
@@ -16,10 +16,12 @@ export const useWordsWithSemesters = () => {
   const onGetSemesters = useSemesters()
 
   const onGetWordsWithSemesters = useCallback(async () => {
-    const semesters = await onGetSemesters()
-    if (!semesters.latestSemesterCode) return // User has never created word even once.
+    const { latestSemesterCode } = await onGetSemesters()
 
-    await onGetWords({ semester: selectedSemester })
+    // If user has selected semester at least once, we should refresh the semester.
+    if (selectedSemester) onGetWords({ semester: selectedSemester })
+    // If not, it should select the latest semester.
+    else onGetWords({ semester: latestSemesterCode }) // User has never created word even once.
   }, [selectedSemester, onGetSemesters, onGetWords])
 
   return onGetWordsWithSemesters

--- a/src/hooks/words/use-words-with-semesters.hook.ts
+++ b/src/hooks/words/use-words-with-semesters.hook.ts
@@ -16,12 +16,14 @@ export const useWordsWithSemesters = () => {
   const onGetSemesters = useSemesters()
 
   const onGetWordsWithSemesters = useCallback(async () => {
-    const { latestSemesterCode } = await onGetSemesters()
+    try {
+      const { latestSemesterCode } = await onGetSemesters()
 
-    // If user has selected semester at least once, we should refresh the semester.
-    if (selectedSemester) onGetWords({ semester: selectedSemester })
-    // If not, it should select the latest semester.
-    else onGetWords({ semester: latestSemesterCode }) // User has never created word even once.
+      // If user has selected semester at least once, we should refresh the semester.
+      if (selectedSemester) onGetWords({ semester: selectedSemester })
+      // If not, it should select the latest semester.
+      else onGetWords({ semester: latestSemesterCode }) // User has never created word even once.
+    } catch {}
   }, [selectedSemester, onGetSemesters, onGetWords])
 
   return onGetWordsWithSemesters


### PR DESCRIPTION
# Background
Latest semester is not selected when you sign in, as the red below:
![image](https://github.com/ajktown/wordnote/assets/53258958/318536e6-dc6b-4b38-8a4b-280105955d48)


## TODOs
- [X] Fix the bug

## Checklist (Developers)
- [X] Make this PR as a draft first
- [X] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
