### PR TITLE
Edit Word during Review Mode

### DIFF
--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC, useCallback, useState } from 'react'
 import { Card, CardActions, CardContent, Typography } from '@mui/material'
 import WordCardFavoriteIcon from '../atom_word_card_favorite_icon'
 import StyledSuspense from '@/organisms/StyledSuspense'
@@ -6,13 +6,24 @@ import { WordData } from '@/api/words/interfaces'
 import TagButtonChunk from '../molecule_tag_button_chunk'
 import WordCardExamplePart from '../atom_word_card_parts/index.example'
 import StyledVisibilityAtom from '@/atoms/StyledVisibility'
-
+import { selectedWordIdForDialogState } from '@/recoil/words/words.state'
+import { useSetRecoilState } from 'recoil'
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+import EditIcon from '@mui/icons-material/Edit'
 interface Props {
   word: WordData
 }
 
 const WordCardReviewMode: FC<Props> = ({ word }) => {
+  const { id } = word
   const [isPeekMode, setPeekMode] = useState(false)
+  const setSelectedWordIdForDialog = useSetRecoilState(
+    selectedWordIdForDialogState,
+  )
+
+  const onClickOpenEditDialog = useCallback(() => {
+    setSelectedWordIdForDialog(id)
+  }, [id, setSelectedWordIdForDialog])
 
   return (
     <StyledSuspense>
@@ -36,6 +47,10 @@ const WordCardReviewMode: FC<Props> = ({ word }) => {
             isVisible={!isPeekMode}
             onClick={() => setPeekMode(!isPeekMode)}
             visibleHoverMessage={`Peek this Wordcard`}
+          />
+          <StyledIconButtonAtom
+            jsxElementButton={<EditIcon fontSize="small" />}
+            onClick={onClickOpenEditDialog}
           />
           <TagButtonChunk wordId={word.id} />
         </CardActions>


### PR DESCRIPTION
# Background
You can edit word during the review
![image](https://github.com/ajktown/wordnote/assets/53258958/4e31da4d-1645-4c58-a8de-fa74b4172934)


## TODOs
- [x] Open edit dialog mode, with edit button

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
