### PR TITLE
Question Mark for Disabled Icons with Hover Message

### DIFF
--- a/src/atoms/StyledIconButton.tsx
+++ b/src/atoms/StyledIconButton.tsx
@@ -51,7 +51,11 @@ const StyledIconButtonAtom: FC<PropsStyledIconButtonAtom> = ({
           aria-label="close"
           onClick={handleClick}
           disabled={isDisabled}
-          style={{ color: buttonColor }}
+          style={{
+            color: buttonColor,
+            cursor:
+              isDisabled && props.hoverMessage?.title ? `help` : undefined,
+          }}
           disableRipple={!props.enableRipple}
         >
           {props.jsxElementButton}

--- a/src/atoms/StyledIconButton.tsx
+++ b/src/atoms/StyledIconButton.tsx
@@ -54,9 +54,7 @@ const StyledIconButtonAtom: FC<PropsStyledIconButtonAtom> = ({
           aria-label="close"
           onClick={handleClick}
           disabled={isDisabled}
-          style={{
-            color: buttonColor,
-          }}
+          style={{ color: buttonColor }}
           disableRipple={!props.enableRipple}
         >
           {props.jsxElementButton}

--- a/src/atoms/StyledIconButton.tsx
+++ b/src/atoms/StyledIconButton.tsx
@@ -52,7 +52,6 @@ const StyledIconButtonAtom: FC<PropsStyledIconButtonAtom> = ({
           onClick={handleClick}
           disabled={isDisabled}
           style={{
-            color: buttonColor,
             cursor:
               isDisabled && props.hoverMessage?.title ? `help` : undefined,
           }}

--- a/src/atoms/StyledIconButton.tsx
+++ b/src/atoms/StyledIconButton.tsx
@@ -44,6 +44,9 @@ const StyledIconButtonAtom: FC<PropsStyledIconButtonAtom> = ({
       placement={props.hoverMessage?.placement || `bottom`}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      style={{
+        cursor: isDisabled && props.hoverMessage?.title ? `help` : undefined,
+      }}
     >
       <span>
         <IconButton
@@ -52,8 +55,7 @@ const StyledIconButtonAtom: FC<PropsStyledIconButtonAtom> = ({
           onClick={handleClick}
           disabled={isDisabled}
           style={{
-            cursor:
-              isDisabled && props.hoverMessage?.title ? `help` : undefined,
+            color: buttonColor,
           }}
           disableRipple={!props.enableRipple}
         >


### PR DESCRIPTION
# Background
https://github.com/ajktown/wordnote/issues/110

## TODOs
- [x] Make the `StyledIconButtonAtom` as `help` when `isDisabled && props.hoverMessage?.title`

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
