### PR TITLE
Kubernetes like issue for wordnote fe

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,32 @@
+name: Bug Report
+description: Report a bug encountered while using Wordnote - AJK Town
+labels:
+  - bug
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How can we reproduce it (as minimally and precisely as possible)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,5 +1,5 @@
-name: Bug Report
-description: Report a bug encountered while using Wordnote - AJK Town
+name: Bug
+description: Report a bug encountered while using the project
 labels:
   - bug
 body:
@@ -27,6 +27,10 @@ body:
       required: true
 
   - type: textarea
-    id: additional
+    id: todos
     attributes:
-      label: Anything else we need to know?
+      label: TODOs
+      value: |
+        ```
+        - [ ] TODO: Write your TODOs here
+        ```

--- a/.github/ISSUE_TEMPLATE/dependency.yaml
+++ b/.github/ISSUE_TEMPLATE/dependency.yaml
@@ -1,0 +1,22 @@
+name: Dependency
+description: Refactor codes/structure for the project
+labels:
+  - dependency
+body:
+  - type: textarea
+    id: documentation
+    attributes:
+      label: What would you like to be refactored?
+      description: |
+        Please provide as much info as possible
+    validations:
+      required: true
+
+  - type: textarea
+    id: todos
+    attributes:
+      label: TODOs
+      value: |
+        ```
+        - [ ] TODO: Write your TODOs here
+        ```

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,29 @@
+name: Documentation
+description: Improve documentation for the project
+labels:
+  - documentation
+body:
+  - type: textarea
+    id: documentation
+    attributes:
+      label: What would you like to be documented?
+      description: |
+        Please provide as much info as possible
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: todos
+    attributes:
+      label: TODOs
+      value: |
+        ```
+        - [ ] TODO: Write your TODOs here
+        ```

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,0 +1,29 @@
+name: Enhancement Tracking Issue
+description: Provide supporting details for a feature in development
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+      description: |
+        Please provide as much info as possible
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: todos
+    attributes:
+      label: TODOs
+      value: |
+        ```
+        - [ ] TODO: Write your TODOs here
+        ```

--- a/.github/ISSUE_TEMPLATE/infrastructure.yaml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yaml
@@ -1,0 +1,29 @@
+name: Infrastructure
+description: Improve CI/CD for the project
+labels:
+  - infra
+body:
+  - type: textarea
+    id: infrastructure
+    attributes:
+      label: What would you like to be added for CI/CD?
+      description: |
+        Please provide as much info as possible
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: todos
+    attributes:
+      label: TODOs
+      value: |
+        ```
+        - [ ] TODO: Write your TODOs here
+        ```

--- a/.github/ISSUE_TEMPLATE/performance.yaml
+++ b/.github/ISSUE_TEMPLATE/performance.yaml
@@ -1,0 +1,22 @@
+name: Performance
+description: Improve performance for the project
+labels:
+  - performance
+body:
+  - type: textarea
+    id: performance
+    attributes:
+      label: What would you like to be changed for the improved performance?
+      description: |
+        Please provide as much info as possible
+    validations:
+      required: true
+
+  - type: textarea
+    id: todos
+    attributes:
+      label: TODOs
+      value: |
+        ```
+        - [ ] TODO: Write your TODOs here
+        ```

--- a/.github/ISSUE_TEMPLATE/refactor.yaml
+++ b/.github/ISSUE_TEMPLATE/refactor.yaml
@@ -1,0 +1,22 @@
+name: Refactor
+description: Refactor codes/structure for the project
+labels:
+  - refactor
+body:
+  - type: textarea
+    id: refactor
+    attributes:
+      label: What would you like to be refactored?
+      description: |
+        Please provide as much info as possible
+    validations:
+      required: true
+
+  - type: textarea
+    id: todos
+    attributes:
+      label: TODOs
+      value: |
+        ```
+        - [ ] TODO: Write your TODOs here
+        ```


### PR DESCRIPTION
# Background
Kubernetes like issue templates for AJK Town.
https://github.com/kubernetes/kubernetes/tree/master/.github/ISSUE_TEMPLATE

## TODOs
- [x] Mock Kubernetes and use similar style of issue templates

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
