### PR TITLE
Customize issue template to the ajktown wordnote based on k8s

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -4,10 +4,11 @@ labels:
   - bug
 body:
   - type: textarea
-    id: problem
+    id: background
     attributes:
-      label: What happened?
+      label: Background
       description: |
+        What happened?
         Please provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/dependency.yaml
+++ b/.github/ISSUE_TEMPLATE/dependency.yaml
@@ -4,10 +4,11 @@ labels:
   - dependency
 body:
   - type: textarea
-    id: documentation
+    id: background
     attributes:
-      label: What would you like to be refactored?
+      label: Background
       description: |
+        What would you like to be refactored?
         Please provide as much info as possible
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/dependency.yaml
+++ b/.github/ISSUE_TEMPLATE/dependency.yaml
@@ -1,5 +1,5 @@
 name: Dependency
-description: Dependency versions updates for the project
+description: Update dependency versions for the project
 labels:
   - dependency
 body:

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -4,7 +4,7 @@ labels:
   - documentation
 body:
   - type: textarea
-    id: documentation
+    id: background
     attributes:
       label: Background
       description: |

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -6,16 +6,10 @@ body:
   - type: textarea
     id: documentation
     attributes:
-      label: What would you like to be documented?
+      label: Background
       description: |
+        What would you like to be documented?
         Please provide as much info as possible
-    validations:
-      required: true
-
-  - type: textarea
-    id: rationale
-    attributes:
-      label: Why is this needed?
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -4,18 +4,12 @@ labels:
   - enhancement
 body:
   - type: textarea
-    id: feature
+    id: background
     attributes:
-      label: What would you like to be added?
+      label: Background
       description: |
-        Please provide as much info as possible
-    validations:
-      required: true
-
-  - type: textarea
-    id: rationale
-    attributes:
-      label: Why is this needed?
+        Before explain the feature, please provide some background and lacking points.
+        What is lacking? What is needed? Why is it needed?
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/infrastructure.yaml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yaml
@@ -4,7 +4,7 @@ labels:
   - infra
 body:
   - type: textarea
-    id: infrastructure
+    id: background
     attributes:
       label: Background
       description: |

--- a/.github/ISSUE_TEMPLATE/infrastructure.yaml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yaml
@@ -6,16 +6,10 @@ body:
   - type: textarea
     id: infrastructure
     attributes:
-      label: What would you like to be added for CI/CD?
+      label: Background
       description: |
+        What would you like to be added for CI/CD?
         Please provide as much info as possible
-    validations:
-      required: true
-
-  - type: textarea
-    id: rationale
-    attributes:
-      label: Why is this needed?
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/performance.yaml
+++ b/.github/ISSUE_TEMPLATE/performance.yaml
@@ -4,7 +4,7 @@ labels:
   - performance
 body:
   - type: textarea
-    id: performance
+    id: background
     attributes:
       label: Background
       description: |

--- a/.github/ISSUE_TEMPLATE/performance.yaml
+++ b/.github/ISSUE_TEMPLATE/performance.yaml
@@ -6,8 +6,9 @@ body:
   - type: textarea
     id: performance
     attributes:
-      label: What would you like to be changed for the improved performance?
+      label: Background
       description: |
+        What would you like to be changed for the improved performance?
         Please provide as much info as possible
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yaml
+++ b/.github/ISSUE_TEMPLATE/refactor.yaml
@@ -4,7 +4,7 @@ labels:
   - refactor
 body:
   - type: textarea
-    id: refactor
+    id: background
     attributes:
       label: What would you like to be refactored?
       description: |

--- a/.github/ISSUE_TEMPLATE/refactor.yaml
+++ b/.github/ISSUE_TEMPLATE/refactor.yaml
@@ -6,8 +6,9 @@ body:
   - type: textarea
     id: background
     attributes:
-      label: What would you like to be refactored?
+      label: Background
       description: |
+        What would you like to be refactored?
         Please provide as much info as possible
     validations:
       required: true


### PR DESCRIPTION
# Background
As I've introduced the issue template in the PR https://github.com/ajktown/wordnote/pull/149,
I first thought it would be better to have "why we need this", but for the current AJK Town projects, I don't think we need to explain why we need it at this point.

Also instead of having a question for background, I think writing "Background" and its sub description would be cleaner to read & matches with the PRs template (which I love)

![image](https://github.com/ajktown/wordnote/assets/53258958/ee55aaf3-1e84-4cc3-a628-788755b2809c)


## TODOs
- [x] Remove why is it needed
- [x] Add Background instead with explanation
- [x] Every label `Background` has the id `background`

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
