### PR TITLE
Fix function name with on~ prefix

### DIFF
--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -1,9 +1,9 @@
-import { FC, useCallback } from 'react'
+import { FC } from 'react'
 import { Card, CardActions, CardContent, Typography } from '@mui/material'
 import WordCardFavoriteIcon from '../atom_word_card_favorite_icon'
 import WordCardDeleteButton from '../atom_word_card_delete_button'
 import WordCardDeleted from './index.deleted'
-import { useRecoilValue, useSetRecoilState } from 'recoil'
+import { useRecoilCallback, useRecoilValue } from 'recoil'
 import WordCardUnknown from './index.unknown'
 import {
   selectedWordIdForDialogState,
@@ -30,14 +30,16 @@ interface Props {
 const WordCard: FC<Props> = ({ wordId, editingMode }) => {
   const word = useRecoilValue(wordsFamily(wordId))
   const isShowingArchived = useRecoilValue(isShowingArchivedState)
-  const setSelectedWordIdForDialog = useSetRecoilState(
-    selectedWordIdForDialogState,
-  )
+
   const isReviewMode = useRecoilValue(isReviewModeState)
 
-  const onClickWordCard = useCallback(() => {
-    !editingMode && setSelectedWordIdForDialog(wordId)
-  }, [editingMode, wordId, setSelectedWordIdForDialog])
+  const onClickWordCard = useRecoilCallback(
+    ({ set }) =>
+      () => {
+        !editingMode && set(selectedWordIdForDialogState, wordId)
+      },
+    [wordId, editingMode],
+  )
 
   if (word === undefined) return <WordCardSkeleton />
   if (word === null) return <WordCardUnknown />

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -35,7 +35,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
   )
   const isReviewMode = useRecoilValue(isReviewModeState)
 
-  const handleClickWordCard = useCallback(() => {
+  const onClickWordCard = useCallback(() => {
     !editingMode && setSelectedWordIdForDialog(wordId)
   }, [editingMode, wordId, setSelectedWordIdForDialog])
 
@@ -50,7 +50,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
   return (
     <StyledSuspense>
       <Card style={{ width: `100%`, borderRadius: 9 }}>
-        <CardContent onClick={handleClickWordCard}>
+        <CardContent onClick={onClickWordCard}>
           <Typography variant="h5" component="div">
             {word.term}
           </Typography>


### PR DESCRIPTION
# Background
(https://github.com/ajktown/wordnote/issues/154)

## TODOs
- [x] Fix the function name
- [x] Use recoilCallback to make lines shorter

```
const onClickWordCard = useRecoilCallback(({ set }) => () => {
    console.log("HIHIHI")
    !editingMode && set(selectedWordIdForDialogState, wordId)
  }, [wordId, editingMode])
```

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [ ] Check if there are any other missing TODOs that are not yet listed
- [ ] Review Code
- [ ] Every item on the checklist has been addressed accordingly
- [ ] If `development` is associated to this PR, you must check if every TODOs are handled
