### PR TITLE
Wordnote Frame with WordCards Count

### DIFF
--- a/src/components/organism_word_card_chunk/index.tsx
+++ b/src/components/organism_word_card_chunk/index.tsx
@@ -22,7 +22,9 @@ const WordCardsChunk: FC = () => {
   return (
     <StyledSuspense>
       <WordCardChunkSearchFound />
-      {wordIds.length} word cards
+      <Typography variant="caption">
+        {wordIds.length} word cards
+      </Typography>
       {wordIds.map((wordId) => (
         <WordCard key={wordId} wordId={wordId} />
       ))}

--- a/src/components/organism_word_card_chunk/index.tsx
+++ b/src/components/organism_word_card_chunk/index.tsx
@@ -9,6 +9,7 @@ import WordCardsChunkNoWordsFound from './index.no_words_found'
 import WordCardChunkSearchFound from './index.search_found'
 import WordIdsPagination from '../atom_word_ids_pagination'
 import { TopOfPageButton } from '../atom_top_of_page_button'
+import { Typography } from '@mui/material'
 
 const WordCardsChunk: FC = () => {
   const searchInput = useRecoilValue(searchInputState)

--- a/src/components/organism_word_card_chunk/index.tsx
+++ b/src/components/organism_word_card_chunk/index.tsx
@@ -22,6 +22,7 @@ const WordCardsChunk: FC = () => {
   return (
     <StyledSuspense>
       <WordCardChunkSearchFound />
+      {wordIds.length} word cards
       {wordIds.map((wordId) => (
         <WordCard key={wordId} wordId={wordId} />
       ))}

--- a/src/components/organism_word_card_frame/index.tsx
+++ b/src/components/organism_word_card_frame/index.tsx
@@ -12,14 +12,18 @@ import WordCardsFramePreferenceButtonPart from '../atom_word_cards_frame_parts/i
 import WordCardsFrameArchiveSwitchPart from '../atom_word_cards_frame_parts/index.archive-switch'
 import WordCardsFrameArchiveModePart from '../atom_word_cards_frame_parts/index.archive-mode'
 import WordCardsFrameReviewModePart from '../atom_word_cards_frame_parts/index.review-mode'
+import { useRecoilValue } from 'recoil'
+import { wordIdsState } from '@/recoil/words/words.state'
 
 const WordCardFrame: FC = () => {
+  const wordIds = useRecoilValue(wordIdsState)
   return (
     <Stack width="100%" alignItems="center">
       <Stack {...WordCardFrameStyle}>
         {/* Header */}
         <Stack direction="row" spacing={0.7} alignItems="center">
           <Box flexGrow={1} />
+          {wordIds.length}
           <WordCardsFrameReviewModePart />
           <WordCardsFrameArchiveSwitchPart />
           <WordCardsFrameSurfingButtonPart />

--- a/src/components/organism_word_card_frame/index.tsx
+++ b/src/components/organism_word_card_frame/index.tsx
@@ -12,18 +12,14 @@ import WordCardsFramePreferenceButtonPart from '../atom_word_cards_frame_parts/i
 import WordCardsFrameArchiveSwitchPart from '../atom_word_cards_frame_parts/index.archive-switch'
 import WordCardsFrameArchiveModePart from '../atom_word_cards_frame_parts/index.archive-mode'
 import WordCardsFrameReviewModePart from '../atom_word_cards_frame_parts/index.review-mode'
-import { useRecoilValue } from 'recoil'
-import { wordIdsState } from '@/recoil/words/words.state'
 
 const WordCardFrame: FC = () => {
-  const wordIds = useRecoilValue(wordIdsState)
   return (
     <Stack width="100%" alignItems="center">
       <Stack {...WordCardFrameStyle}>
         {/* Header */}
         <Stack direction="row" spacing={0.7} alignItems="center">
           <Box flexGrow={1} />
-          {wordIds.length}
           <WordCardsFrameReviewModePart />
           <WordCardsFrameArchiveSwitchPart />
           <WordCardsFrameSurfingButtonPart />


### PR DESCRIPTION
# Background
(https://github.com/ajktown/wordnote/issues/134)

## TODOs
- [x] Make sure how many word cards are available in the view

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
