### PR TITLE
refactor onSignOutApp function name

### DIFF
--- a/src/hooks/app/use-is-app-booted.hook.ts
+++ b/src/hooks/app/use-is-app-booted.hook.ts
@@ -8,7 +8,7 @@ import { useAuthPrep } from '../auth/use-auth-prep.hook'
 
 export const useIsAppBooted = (): boolean => {
   const isBooted = useRecoilValue(isAppBootedSelector)
-  const handleSignOutApp = useOnSignOutApp()
+  const onSignOutApp = useOnSignOutApp()
   const onGetAuthPrep = useAuthPrep()
   const router = useRouter()
 
@@ -24,9 +24,9 @@ export const useIsAppBooted = (): boolean => {
 
       router.push(DEFAULT_MAIN_APP_PAGE)
     } catch {
-      await handleSignOutApp()
+      await onSignOutApp()
     }
-  }, [onGetAuthPrep, handleSignOutApp, router])
+  }, [onGetAuthPrep, onSignOutApp, router])
 
   useEffect(() => {
     if (isBooted) return

--- a/src/hooks/use-handle-api-error.hook.ts
+++ b/src/hooks/use-handle-api-error.hook.ts
@@ -6,7 +6,7 @@ import { useOnSignOutApp } from './app/use-on-sign-out-app.hook'
 type OnHandleApiError = (err: unknown) => any
 
 export const useHandleApiError = () => {
-  const onApiErrorHook = useOnSignOutApp()
+  const onSignOutApp = useOnSignOutApp()
 
   const onHandleApiError: OnHandleApiError = useRecoilCallback(
     ({ set }) =>
@@ -15,10 +15,10 @@ export const useHandleApiError = () => {
 
         const error = CustomizedApiError.fromUnknown(err)
         if (error.props.statusCode === 401) {
-          await onApiErrorHook()
+          await onSignOutApp()
         }
       },
-    [onApiErrorHook],
+    [onSignOutApp],
   )
 
   return onHandleApiError


### PR DESCRIPTION
# Background
issue https://github.com/ajktown/wordnote/issues/44
We refactored the function names in the PR(https://github.com/ajktown/wordnote/pull/158), but there were components that were not changed.

## TODOs
- [x] Refactor every hook to have the prefix `on` for functions they return
- [x] Refactor every component that takes the function from hook to keep the same name

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
Please copy and paste the following into your review, ensuring each checkbox is marked as checked
```
- [ ] Check if there are any other missing TODOs that are not yet listed
- [ ] Review Code
- [ ] Every item on the checklist has been addressed accordingly
- [ ] If `development` is associated to this PR, you must check if every TODOs are handled
```
