### PR TITLE
refactor names of functionaries

### DIFF
--- a/src/components/atom_word_card_add_tag_button/index.tsx
+++ b/src/components/atom_word_card_add_tag_button/index.tsx
@@ -21,8 +21,11 @@ const WordCardAddTagButton: FC<Props> = ({ wordId }) => {
     setInput(``)
     setAddingMode(false)
   }, [])
-  const [loading, onAddTag] = usePutWordTagAdded(wordId, onResetInput)
-  const onClick = useCallback(() => onAddTag(input), [input, onAddTag])
+  const [loading, onPutWordTagAdded] = usePutWordTagAdded(wordId, onResetInput)
+  const onClick = useCallback(
+    () => onPutWordTagAdded(input),
+    [input, onPutWordTagAdded],
+  )
 
   return (
     <Fragment>

--- a/src/components/atom_word_card_add_tag_button/index.tsx
+++ b/src/components/atom_word_card_add_tag_button/index.tsx
@@ -16,7 +16,7 @@ const WordCardAddTagButton: FC<Props> = ({ wordId }) => {
   const [input, setInput] = useState(``)
 
   const onClickOpen = useCallback(async () => setAddingMode(true), [])
-  const [inputRef, onGetDynamicFocus] = useDynamicFocus(onClickOpen)
+  const [inputRef, onDynamicFocus] = useDynamicFocus(onClickOpen)
   const onResetInput = useCallback(() => {
     setInput(``)
     setAddingMode(false)
@@ -29,7 +29,7 @@ const WordCardAddTagButton: FC<Props> = ({ wordId }) => {
 
   return (
     <Fragment>
-      <StyledChip label={`+`} loading={loading} onClick={onGetDynamicFocus} />
+      <StyledChip label={`+`} loading={loading} onClick={onDynamicFocus} />
       {isAddingMode && (
         <StyledDialog
           visuals={{ maxWidth: `xs` }}

--- a/src/components/atom_word_card_add_tag_button/index.tsx
+++ b/src/components/atom_word_card_add_tag_button/index.tsx
@@ -16,7 +16,7 @@ const WordCardAddTagButton: FC<Props> = ({ wordId }) => {
   const [input, setInput] = useState(``)
 
   const onClickOpen = useCallback(async () => setAddingMode(true), [])
-  const [inputRef, onClickOpenWithFocus] = useDynamicFocus(onClickOpen)
+  const [inputRef, onGetDynamicFocus] = useDynamicFocus(onClickOpen)
   const onResetInput = useCallback(() => {
     setInput(``)
     setAddingMode(false)
@@ -29,11 +29,7 @@ const WordCardAddTagButton: FC<Props> = ({ wordId }) => {
 
   return (
     <Fragment>
-      <StyledChip
-        label={`+`}
-        loading={loading}
-        onClick={onClickOpenWithFocus}
-      />
+      <StyledChip label={`+`} loading={loading} onClick={onGetDynamicFocus} />
       {isAddingMode && (
         <StyledDialog
           visuals={{ maxWidth: `xs` }}

--- a/src/components/atom_word_card_favorite_icon/index.tsx
+++ b/src/components/atom_word_card_favorite_icon/index.tsx
@@ -6,14 +6,14 @@ interface Props {
   wordId: string
 }
 const WordCardFavoriteIcon: FC<Props> = ({ wordId }) => {
-  const [word, handlePutWordFavorite] = usePutWordFavorite(wordId)
+  const [word, onPutWordFavorite] = usePutWordFavorite(wordId)
 
   if (!word) return null
 
   return (
     <StyledIconButtonFavorite
       isClicked={word.isFavorite}
-      onClick={handlePutWordFavorite}
+      onClick={onPutWordFavorite}
     />
   )
 }

--- a/src/components/molecule_new_word_box/index.tsx
+++ b/src/components/molecule_new_word_box/index.tsx
@@ -30,13 +30,13 @@ const NewWordBox: FC = () => {
     onClickPostWordWritingModeOpen,
   ] = usePostWordWithStringHook()
 
-  const [inputRef, onPostWordWithFocus] = useDynamicFocus(
+  const [inputRef, onGetDynamicFocus] = useDynamicFocus(
     onClickPostWordWritingModeOpen,
   )
   const onHitEnter = useCallback(() => {
-    if (isWritingMode) onPostWordWithFocus()
+    if (isWritingMode) onGetDynamicFocus()
     else setWritingMode(true)
-  }, [isWritingMode, setWritingMode, onPostWordWithFocus])
+  }, [isWritingMode, setWritingMode, onGetDynamicFocus])
 
   useKeyPress(`Enter`, onHitEnter)
   useKeyPress(`Escape`, onClickPostWordWritingModeClose)

--- a/src/components/molecule_new_word_box/index.tsx
+++ b/src/components/molecule_new_word_box/index.tsx
@@ -30,13 +30,13 @@ const NewWordBox: FC = () => {
     onClickPostWordWritingModeOpen,
   ] = usePostWordWithStringHook()
 
-  const [inputRef, onGetDynamicFocus] = useDynamicFocus(
+  const [inputRef, onDynamicFocus] = useDynamicFocus(
     onClickPostWordWritingModeOpen,
   )
   const onHitEnter = useCallback(() => {
-    if (isWritingMode) onGetDynamicFocus()
+    if (isWritingMode) onDynamicFocus()
     else setWritingMode(true)
-  }, [isWritingMode, setWritingMode, onGetDynamicFocus])
+  }, [isWritingMode, setWritingMode, onDynamicFocus])
 
   useKeyPress(`Enter`, onHitEnter)
   useKeyPress(`Escape`, onClickPostWordWritingModeClose)

--- a/src/components/organism_word_card_chunk/index.search_not_found.tsx
+++ b/src/components/organism_word_card_chunk/index.search_not_found.tsx
@@ -11,13 +11,13 @@ const WordCardChunkSearchNotFound: FC = () => {
   const searchInput = useRecoilValue(searchInputState)
   const [, onResetSearchInput] = useResetSearchInput()
   const setSearchInput = useSetRecoilState(searchInputState)
-  const postWord = usePostWord()
+  const onPostWord = usePostWord()
 
   const handleClickPostWord = useCallback(() => {
     const parsed = parseInputIntoWordLambda(searchInput)
-    postWord(parsed)
+    onPostWord(parsed)
     setSearchInput(parsed.term)
-  }, [searchInput, postWord, setSearchInput])
+  }, [searchInput, onPostWord, setSearchInput])
 
   return (
     <Stack>

--- a/src/hooks/preference/use-put-preference-native-language.hook.ts
+++ b/src/hooks/preference/use-put-preference-native-language.hook.ts
@@ -6,7 +6,7 @@ import { usePutPreference } from './use-put-preference.hook'
 export const usePutPreferenceNativeLanguage = (
   languageCode: GlobalLanguageCode,
 ) => {
-  const onUsePutPreference = usePutPreference()
+  const onPutPreference = usePutPreference()
   const onPutPreferenceNativeLanguage = useRecoilCallback(
     ({ snapshot }) =>
       async (_, checked: boolean) => {
@@ -23,10 +23,10 @@ export const usePutPreferenceNativeLanguage = (
           const nativeLanguages: GlobalLanguageCode[] =
             Array.from(nativeLanguagesSet)
 
-          await onUsePutPreference({ nativeLanguages })
+          await onPutPreference({ nativeLanguages })
         } catch {}
       },
-    [onUsePutPreference, languageCode],
+    [onPutPreference, languageCode],
   )
 
   return onPutPreferenceNativeLanguage

--- a/src/hooks/use-dynamic-focus.hook.ts
+++ b/src/hooks/use-dynamic-focus.hook.ts
@@ -21,10 +21,10 @@ export const useDynamicFocus = (
     }, milliSecondsWait)
   }, [ref, milliSecondsWait])
 
-  const onGetDynamicFocus = useCallback(async () => {
+  const onDynamicFocus = useCallback(async () => {
     await handleClick()
     setFocus()
   }, [handleClick, setFocus])
 
-  return [ref, onGetDynamicFocus]
+  return [ref, onDynamicFocus]
 }

--- a/src/hooks/use-dynamic-focus.hook.ts
+++ b/src/hooks/use-dynamic-focus.hook.ts
@@ -21,10 +21,10 @@ export const useDynamicFocus = (
     }, milliSecondsWait)
   }, [ref, milliSecondsWait])
 
-  const onDynamicFocus = useCallback(async () => {
+  const onGetDynamicFocus = useCallback(async () => {
     await handleClick()
     setFocus()
   }, [handleClick, setFocus])
 
-  return [ref, onDynamicFocus]
+  return [ref, onGetDynamicFocus]
 }

--- a/src/hooks/words/use-post-word-with-string.hook.ts
+++ b/src/hooks/words/use-post-word-with-string.hook.ts
@@ -15,7 +15,7 @@ type UsePostWordWithStringHook = [
 ]
 
 export const usePostWordWithStringHook = (): UsePostWordWithStringHook => {
-  const handlePostWord = usePostWord()
+  const onPostWord = usePostWord()
   const [userInput, setUserInput] = useState(``)
   const [loading, setLoading] = useState(false)
   const [isWritingMode, setWritingMode] = useState(false)
@@ -29,7 +29,7 @@ export const usePostWordWithStringHook = (): UsePostWordWithStringHook => {
       try {
         setLoading(true)
         const newWord: PostWordReqDto = parseInputIntoWordLambda(userInput)
-        await handlePostWord(newWord)
+        await onPostWord(newWord)
       } finally {
         setLoading(false)
       }
@@ -37,7 +37,7 @@ export const usePostWordWithStringHook = (): UsePostWordWithStringHook => {
       setUserInput(``)
       withWritingModeClosed && setWritingMode(false)
     },
-    [userInput, handlePostWord],
+    [userInput, onPostWord],
   )
 
   const onClickPostWordWritingModeClose = useCallback(


### PR DESCRIPTION
# Background
issue https://github.com/ajktown/wordnote/issues/44
We refactored the function names in the PRs(https://github.com/ajktown/wordnote/pull/158 & https://github.com/ajktown/wordnote/pull/163), but there were components that were not changed.

## TODOs
- [x]  Refactor every hook to have the prefix on for functions they return
- [x]  Refactor every component that takes the function from hook to keep the same name

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
Please copy and paste the following into your review, ensuring each checkbox is marked as checked
```
- [ ] Check if there are any other missing TODOs that are not yet listed
- [ ] Review Code
- [ ] Every item on the checklist has been addressed accordingly
- [ ] If `development` is associated to this PR, you must check if every TODOs are handled
```
