### PR TITLE
Review Mode with More Action Buttons

### DIFF
--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useState } from 'react'
+import { FC, useState } from 'react'
 import { Card, CardActions, CardContent, Typography } from '@mui/material'
 import WordCardFavoriteIcon from '../atom_word_card_favorite_icon'
 import StyledSuspense from '@/organisms/StyledSuspense'
@@ -7,9 +7,11 @@ import TagButtonChunk from '../molecule_tag_button_chunk'
 import WordCardExamplePart from '../atom_word_card_parts/index.example'
 import StyledVisibilityAtom from '@/atoms/StyledVisibility'
 import { selectedWordIdForDialogState } from '@/recoil/words/words.state'
-import { useSetRecoilState } from 'recoil'
-import StyledIconButtonAtom from '@/atoms/StyledIconButton'
-import EditIcon from '@mui/icons-material/Edit'
+import { useRecoilCallback } from 'recoil'
+import WordCardArchiveButtonPart from '../atom_word_card_parts/index.archive-button'
+import WordCardUnarchiveButtonPart from '../atom_word_card_parts/index.unarchive-button'
+import WordCardShareButtonPart from '../atom_word_card_parts/index.share-button'
+import DictLinkButtonChunk from '../molecule_dict_link_button_chunk'
 interface Props {
   word: WordData
 }
@@ -17,18 +19,19 @@ interface Props {
 const WordCardReviewMode: FC<Props> = ({ word }) => {
   const { id } = word
   const [isPeekMode, setPeekMode] = useState(false)
-  const setSelectedWordIdForDialog = useSetRecoilState(
-    selectedWordIdForDialogState,
-  )
 
-  const onClickOpenEditDialog = useCallback(() => {
-    setSelectedWordIdForDialog(id)
-  }, [id, setSelectedWordIdForDialog])
+  const onClickWordCard = useRecoilCallback(
+    ({ set }) =>
+      () => {
+        set(selectedWordIdForDialogState, id)
+      },
+    [id],
+  )
 
   return (
     <StyledSuspense>
       <Card style={{ width: `100%`, borderRadius: 9 }}>
-        <CardContent>
+        <CardContent onClick={onClickWordCard}>
           <Typography variant="h5" component="div">
             {isPeekMode ? word.term : `???`}
           </Typography>
@@ -46,13 +49,17 @@ const WordCardReviewMode: FC<Props> = ({ word }) => {
           <StyledVisibilityAtom
             isVisible={!isPeekMode}
             onClick={() => setPeekMode(!isPeekMode)}
-            visibleHoverMessage={`Peek this Wordcard`}
+            visibleHoverMessage={`Peek this word card`}
           />
-          <StyledIconButtonAtom
-            jsxElementButton={<EditIcon fontSize="small" />}
-            onClick={onClickOpenEditDialog}
-          />
+          {isPeekMode && !word.isArchived && (
+            <WordCardArchiveButtonPart wordId={word.id} />
+          )}
+          {isPeekMode && word.isArchived && (
+            <WordCardUnarchiveButtonPart wordId={word.id} />
+          )}
+          {isPeekMode && <WordCardShareButtonPart wordId={word.id} />}
           <TagButtonChunk wordId={word.id} />
+          <DictLinkButtonChunk wordId={word.id} />
         </CardActions>
       </Card>
     </StyledSuspense>


### PR DESCRIPTION
# Background
Current action buttons during the review mode is limited and a bit inconvenient.

- Problem: Review Mode & Non Peek Mode
  - No dictionary
  - Unnecessary editing icon that is different from normal mode
![image](https://github.com/ajktown/wordnote/assets/53258958/1fa556ab-140b-4f03-956a-5bf42aa897ec)

- Problem: Review Mode & Peek Mode
  - Not enough action buttons that 
  - Unnecessary editing icon that is different from normal mode
![image](https://github.com/ajktown/wordnote/assets/53258958/2c611a18-cf1c-4e70-a46f-726dd646506d)

## TODOs
- [x] Review Mode & Non Peek Mode with more action buttons
- [x] Review Mode & Peek Mode with more action buttons

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled

