### PR TITLE
Showing Customized Tag on Shared Word Card

### DIFF
--- a/src/api/words/interfaces/index.ts
+++ b/src/api/words/interfaces/index.ts
@@ -10,6 +10,7 @@ export interface ISharedWord {
   definition: string
   example: string
   exampleLink: string
+  tags: string[]
 }
 
 export interface WordData extends ISharedWord, DataStatus, DataBasics {
@@ -17,7 +18,6 @@ export interface WordData extends ISharedWord, DataStatus, DataBasics {
   userId: string
   semester: number
   isFavorite: boolean
-  tags: string[]
   dateAdded?: number
   isArchived: boolean
 }

--- a/src/components/molecule_word_card/index.shared.tsx
+++ b/src/components/molecule_word_card/index.shared.tsx
@@ -11,15 +11,17 @@ import { PageConst } from '@/constants/pages.constant'
 import { PageQueryConst } from '@/constants/page-queries.constant'
 import StyledCountdownTimer from '@/atoms/StyledCountdownTimer'
 import TagButtonLanguage from '../atom_tag_chip/index.language'
+import TagChipCustomized from '../atom_tag_chip/index.customized'
 
 interface Props {
   wordId: string
+  clickDisabled?: boolean
 }
 
 const URL_PATH = `/` + PageConst.Share + `?` + PageQueryConst.wordID + `=`
 
-const WordCardShared: FC<Props> = ({ wordId }) => {
-  const sharedWord = useRecoilValue(sharedWordFamily(wordId))
+const WordCardShared: FC<Props> = ({ wordId, clickDisabled }) => {
+  const sharedData = useRecoilValue(sharedWordFamily(wordId))
 
   const onClickCopyUrl = useCallback(() => {
     const { origin } = window.location // like http://localhost:3000
@@ -34,8 +36,8 @@ const WordCardShared: FC<Props> = ({ wordId }) => {
     [wordId],
   )
 
-  if (sharedWord === undefined) return <WordCardSkeleton />
-  if (sharedWord === null || sharedWord.word === null)
+  if (sharedData === undefined) return <WordCardSkeleton />
+  if (sharedData === null || sharedData.word === null)
     return <WordCardUnknown />
 
   return (
@@ -43,26 +45,34 @@ const WordCardShared: FC<Props> = ({ wordId }) => {
       <Card style={{ width: `100%`, borderRadius: 9 }}>
         <CardContent>
           <Typography variant="h5" component="div">
-            {sharedWord.word.term}
+            {sharedData.word.term}
           </Typography>
           <Typography sx={{ mb: 1.5 }} color="text.secondary">
-            {sharedWord.word.pronunciation}
+            {sharedData.word.pronunciation}
           </Typography>
           <Typography variant="body2">
-            {sharedWord.word.definition}
+            {sharedData.word.definition}
             <br />
           </Typography>
-          <WordCardExamplePart word={sharedWord.word} />
+          <WordCardExamplePart word={sharedData.word} />
         </CardContent>
         <CardActions>
           <TagButtonLanguage
-            languageCode={sharedWord.word.languageCode}
+            languageCode={sharedData.word.languageCode}
             clickDisabled
           />
+          {sharedData.word.tags.map((tag) => (
+            <TagChipCustomized
+              key={tag}
+              label={tag}
+              clickDisabled={clickDisabled}
+            />
+          ))}
+
           <StyledTextButtonAtom title={`copy URL`} onClick={onClickCopyUrl} />
           <Box mr={0.5} />
           <StyledCountdownTimer
-            targetTime={sharedWord.sharedResource.expireInSecs}
+            targetTime={sharedData.sharedResource.expireInSecs}
             onHandleExpire={onHandleExpire}
           />
         </CardActions>

--- a/src/components/molecule_word_card/index.shared.tsx
+++ b/src/components/molecule_word_card/index.shared.tsx
@@ -68,7 +68,6 @@ const WordCardShared: FC<Props> = ({ wordId, clickDisabled }) => {
               clickDisabled={clickDisabled}
             />
           ))}
-
           <StyledTextButtonAtom title={`copy URL`} onClick={onClickCopyUrl} />
           <Box mr={0.5} />
           <StyledCountdownTimer

--- a/src/components/molecule_word_card/index.shared.tsx
+++ b/src/components/molecule_word_card/index.shared.tsx
@@ -21,7 +21,7 @@ interface Props {
 const URL_PATH = `/` + PageConst.Share + `?` + PageQueryConst.wordID + `=`
 
 const WordCardShared: FC<Props> = ({ wordId, clickDisabled }) => {
-  const sharedData = useRecoilValue(sharedWordFamily(wordId))
+  const sharedWord = useRecoilValue(sharedWordFamily(wordId))
 
   const onClickCopyUrl = useCallback(() => {
     const { origin } = window.location // like http://localhost:3000
@@ -36,8 +36,8 @@ const WordCardShared: FC<Props> = ({ wordId, clickDisabled }) => {
     [wordId],
   )
 
-  if (sharedData === undefined) return <WordCardSkeleton />
-  if (sharedData === null || sharedData.word === null)
+  if (sharedWord === undefined) return <WordCardSkeleton />
+  if (sharedWord === null || sharedWord.word === null)
     return <WordCardUnknown />
 
   return (
@@ -45,23 +45,23 @@ const WordCardShared: FC<Props> = ({ wordId, clickDisabled }) => {
       <Card style={{ width: `100%`, borderRadius: 9 }}>
         <CardContent>
           <Typography variant="h5" component="div">
-            {sharedData.word.term}
+            {sharedWord.word.term}
           </Typography>
           <Typography sx={{ mb: 1.5 }} color="text.secondary">
-            {sharedData.word.pronunciation}
+            {sharedWord.word.pronunciation}
           </Typography>
           <Typography variant="body2">
-            {sharedData.word.definition}
+            {sharedWord.word.definition}
             <br />
           </Typography>
-          <WordCardExamplePart word={sharedData.word} />
+          <WordCardExamplePart word={sharedWord.word} />
         </CardContent>
         <CardActions>
           <TagButtonLanguage
-            languageCode={sharedData.word.languageCode}
+            languageCode={sharedWord.word.languageCode}
             clickDisabled
           />
-          {sharedData.word.tags.map((tag) => (
+          {sharedWord.word.tags.map((tag) => (
             <TagChipCustomized
               key={tag}
               label={tag}
@@ -72,7 +72,7 @@ const WordCardShared: FC<Props> = ({ wordId, clickDisabled }) => {
           <StyledTextButtonAtom title={`copy URL`} onClick={onClickCopyUrl} />
           <Box mr={0.5} />
           <StyledCountdownTimer
-            targetTime={sharedData.sharedResource.expireInSecs}
+            targetTime={sharedWord.sharedResource.expireInSecs}
             onHandleExpire={onHandleExpire}
           />
         </CardActions>

--- a/src/components/molecule_word_card/index.shared.tsx
+++ b/src/components/molecule_word_card/index.shared.tsx
@@ -15,12 +15,11 @@ import TagChipCustomized from '../atom_tag_chip/index.customized'
 
 interface Props {
   wordId: string
-  clickDisabled?: boolean
 }
 
 const URL_PATH = `/` + PageConst.Share + `?` + PageQueryConst.wordID + `=`
 
-const WordCardShared: FC<Props> = ({ wordId, clickDisabled }) => {
+const WordCardShared: FC<Props> = ({ wordId }) => {
   const sharedWord = useRecoilValue(sharedWordFamily(wordId))
 
   const onClickCopyUrl = useCallback(() => {
@@ -62,11 +61,7 @@ const WordCardShared: FC<Props> = ({ wordId, clickDisabled }) => {
             clickDisabled
           />
           {sharedWord.word.tags.map((tag) => (
-            <TagChipCustomized
-              key={tag}
-              label={tag}
-              clickDisabled={clickDisabled}
-            />
+            <TagChipCustomized key={tag} label={tag} clickDisabled />
           ))}
           <StyledTextButtonAtom title={`copy URL`} onClick={onClickCopyUrl} />
           <Box mr={0.5} />

--- a/src/pages/share/index.tsx
+++ b/src/pages/share/index.tsx
@@ -23,10 +23,10 @@ const SharePage: FC = () => {
     )
   return (
     <StyledCentered>
-      <Typography variant="h5">
+      <Typography variant="h5" style={{ border: `3px solid yellow` }}>
         {`Beta feature: Below is the shared word card`}
       </Typography>
-      <Stack minWidth={700}>
+      <Stack minWidth={700} style={{ border: `3px solid red` }}>
         <WordCardShared wordId={wordId.trim()} />
       </Stack>
     </StyledCentered>

--- a/src/pages/share/index.tsx
+++ b/src/pages/share/index.tsx
@@ -23,10 +23,10 @@ const SharePage: FC = () => {
     )
   return (
     <StyledCentered>
-      <Typography variant="h5" style={{ border: `3px solid yellow` }}>
+      <Typography variant="h5">
         {`Beta feature: Below is the shared word card`}
       </Typography>
-      <Stack minWidth={700} style={{ border: `3px solid red` }}>
+      <Stack minWidth={700}>
         <WordCardShared wordId={wordId.trim()} />
       </Stack>
     </StyledCentered>


### PR DESCRIPTION
# Background
https://github.com/ajktown/wordnote/issues/164

## TODOs
- [x] Implement unclickable tags for shared word card

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
Please copy and paste the following into your review, ensuring each checkbox is marked as checked
```
- [ ] Check if there are any other missing TODOs that are not yet listed
- [ ] Review Code
- [ ] Every item on the checklist has been addressed accordingly
- [ ] If `development` is associated to this PR, you must check if every TODOs are handled
```
