### PR TITLE
Fix the variable naming from sharedWord to sharedData

### DIFF
--- a/src/components/dialog_shared_resource/index.tsx
+++ b/src/components/dialog_shared_resource/index.tsx
@@ -14,7 +14,7 @@ import WordCardShareReview from '../molecule_word_card/index.share-review'
 
 const SharedResourceDialog: FC = () => {
   const sharedWordId = useRecoilValue(sharedWordIdState)
-  const sharedWord = useRecoilValue(sharedWordFamily(sharedWordId))
+  const sharedData = useRecoilValue(sharedWordFamily(sharedWordId))
   const onClose = useResetRecoilState(sharedWordIdState)
   const [posting, setPosting] = useState(false)
 
@@ -40,9 +40,9 @@ const SharedResourceDialog: FC = () => {
 
   if (!sharedWordId) return null
 
-  if (sharedWord === undefined) return <StyledDialogLoading />
+  if (sharedData === undefined) return <StyledDialogLoading />
 
-  if (sharedWord === null)
+  if (sharedData === null)
     return (
       <StyledDialog onClose={onClose}>
         <DialogTitle>{`Beta Feature: Share Word Card?`}</DialogTitle>

--- a/src/components/molecule_word_card/index.shared.tsx
+++ b/src/components/molecule_word_card/index.shared.tsx
@@ -19,7 +19,7 @@ interface Props {
 const URL_PATH = `/` + PageConst.Share + `?` + PageQueryConst.wordID + `=`
 
 const WordCardShared: FC<Props> = ({ wordId }) => {
-  const sharedWord = useRecoilValue(sharedWordFamily(wordId))
+  const sharedData = useRecoilValue(sharedWordFamily(wordId))
 
   const onClickCopyUrl = useCallback(() => {
     const { origin } = window.location // like http://localhost:3000
@@ -34,8 +34,8 @@ const WordCardShared: FC<Props> = ({ wordId }) => {
     [wordId],
   )
 
-  if (sharedWord === undefined) return <WordCardSkeleton />
-  if (sharedWord === null || sharedWord.word === null)
+  if (sharedData === undefined) return <WordCardSkeleton />
+  if (sharedData === null || sharedData.word === null)
     return <WordCardUnknown />
 
   return (
@@ -43,26 +43,26 @@ const WordCardShared: FC<Props> = ({ wordId }) => {
       <Card style={{ width: `100%`, borderRadius: 9 }}>
         <CardContent>
           <Typography variant="h5" component="div">
-            {sharedWord.word.term}
+            {sharedData.word.term}
           </Typography>
           <Typography sx={{ mb: 1.5 }} color="text.secondary">
-            {sharedWord.word.pronunciation}
+            {sharedData.word.pronunciation}
           </Typography>
           <Typography variant="body2">
-            {sharedWord.word.definition}
+            {sharedData.word.definition}
             <br />
           </Typography>
-          <WordCardExamplePart word={sharedWord.word} />
+          <WordCardExamplePart word={sharedData.word} />
         </CardContent>
         <CardActions>
           <TagButtonLanguage
-            languageCode={sharedWord.word.languageCode}
+            languageCode={sharedData.word.languageCode}
             clickDisabled
           />
           <StyledTextButtonAtom title={`copy URL`} onClick={onClickCopyUrl} />
           <Box mr={0.5} />
           <StyledCountdownTimer
-            targetTime={sharedWord.sharedResource.expireInSecs}
+            targetTime={sharedData.sharedResource.expireInSecs}
             onHandleExpire={onHandleExpire}
           />
         </CardActions>


### PR DESCRIPTION
# Background
https://github.com/ajktown/wordnote/issues/173

## TODOs
- [x] Fix the Naming `sharedWord` => `sharedData`

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
Please copy and paste the following into your review, ensuring each checkbox is marked as checked
```
- [ ] Check if there are any other missing TODOs that are not yet listed
- [ ] Review Code
- [ ] Every item on the checklist has been addressed accordingly
- [ ] If `development` is associated to this PR, you must check if every TODOs are handled
```
