### PR TITLE
Underscore during the review mode

### DIFF
--- a/src/components/atom_word_card_parts/index.example.tsx
+++ b/src/components/atom_word_card_parts/index.example.tsx
@@ -19,8 +19,27 @@ const WordCardExamplePart: FC<Props> = ({ word, reviewMode }) => {
   const exampleTrimmed = word.example.trim()
   const linkExampleTrimmed = word.exampleLink.trim()
 
-  if (reviewMode)
+  // does it have two double quote?
+  const hasTwoDoubleQuotes = exampleTrimmed.match(/"/g)?.length === 2
+
+  if (reviewMode && !hasTwoDoubleQuotes)
     return <Typography variant={PRIVATE_VARIANT}>{`???`}</Typography>
+
+  // only show non-double quote strings and the double quote becomes ???
+  if (reviewMode && hasTwoDoubleQuotes) {
+    // splice the string
+    const firstQuote = exampleTrimmed.indexOf(`"`)
+    const secondQuote = exampleTrimmed.indexOf(`"`, firstQuote + 1)
+
+    return (
+      <Typography variant={PRIVATE_VARIANT}>
+        {exampleTrimmed.slice(0, firstQuote) +
+          `_` + // default underline is 1 character
+          word.term.replace(/./g, `_`) +
+          exampleTrimmed.slice(secondQuote + 1)}
+      </Typography>
+    )
+  }
 
   if (!exampleTrimmed && linkExampleTrimmed)
     return (
@@ -34,13 +53,11 @@ const WordCardExamplePart: FC<Props> = ({ word, reviewMode }) => {
   if (!linkExampleTrimmed && !exampleTrimmed) return null
 
   if (!linkExampleTrimmed)
-    return (
-      <Typography variant={PRIVATE_VARIANT}>{`"${exampleTrimmed}"`}</Typography>
-    )
+    return <Typography variant={PRIVATE_VARIANT}>{exampleTrimmed}</Typography>
 
   return (
     <Link href={linkExampleTrimmed} target="_blank">
-      <Typography variant={PRIVATE_VARIANT}>{`"${exampleTrimmed}"`}</Typography>
+      <Typography variant={PRIVATE_VARIANT}>{exampleTrimmed}</Typography>
     </Link>
   )
 }


### PR DESCRIPTION
# Background
During the review mode, only by looking at the meaning of term is not enough to test yourself.

## TODOs
- [x] Implement underscore feature for wordcard
normal mode:
yes double quote in red, and no double quote in orange
![image](https://github.com/ajktown/wordnote/assets/53258958/09057193-449f-4b95-991f-f55dae51ecf2)

review mode:
Shows the example sentence in red, but not in orange (due to insufficient information)
![image](https://github.com/ajktown/wordnote/assets/53258958/3071baf4-6d71-4392-a5ad-70968f166f46)


## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)

- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled

