### PR TITLE
SearchInput searches is non-semester scoped

### DIFF
--- a/src/components/atom_tag_chip/index.semester-code.tsx
+++ b/src/components/atom_tag_chip/index.semester-code.tsx
@@ -1,0 +1,21 @@
+import StyledChip from '@/atoms/StyledChip'
+import { FC } from 'react'
+
+interface Props {
+  semesterCode: number // semester code i.e) 224 => 2022Y 4Q
+}
+const TagChipSemesterCode: FC<Props> = ({ semesterCode }) => {
+  // parsing semester code
+  const year = Math.floor(semesterCode / 10)
+  const quarter = semesterCode % 10
+
+  return (
+    <StyledChip
+      key={semesterCode}
+      clickDisabled
+      label={`20${year}Y ${quarter}Q`}
+    />
+  )
+}
+
+export default TagChipSemesterCode

--- a/src/components/molecule_tag_button_chunk/index.tsx
+++ b/src/components/molecule_tag_button_chunk/index.tsx
@@ -4,6 +4,7 @@ import { FC } from 'react'
 import { useRecoilValue } from 'recoil'
 import TagChipCustomized from '../atom_tag_chip/index.customized'
 import TagChipLanguage from '../atom_tag_chip/index.language'
+import TagChipSemesterCode from '../atom_tag_chip/index.semester-code'
 
 interface Props {
   wordId: string
@@ -20,6 +21,7 @@ const TagButtonChunk: FC<Props> = ({ wordId, clickDisabled }) => {
       spacing={0.2}
       sx={{ flexWrap: `wrap`, rowGap: `3px` }}
     >
+      <TagChipSemesterCode semesterCode={word.semester} />
       <TagChipLanguage
         languageCode={word.languageCode}
         clickDisabled={clickDisabled}

--- a/src/hooks/words/use-words.hook.ts
+++ b/src/hooks/words/use-words.hook.ts
@@ -9,7 +9,7 @@ import { useState } from 'react'
 import { useRecoilCallback } from 'recoil'
 import { useHandleApiError } from '../use-handle-api-error.hook'
 import { useApplySemesterDetails } from '../semesters/use-apply-semester-details'
-import { getWordsApi } from '@/api/words/get-words.api'
+import { GetWordsApi, getWordsApi } from '@/api/words/get-words.api'
 
 type NewParams = Partial<GetWordParams>
 type HandleRefresh = (newParams?: NewParams) => Promise<void>
@@ -30,7 +30,18 @@ export const useWords = (): UseWordIds => {
             ...newParams,
           }
           set(getWordsParamsState, params)
-          const [apiResponse] = await getWordsApi(params)
+
+          let apiResponse: undefined | GetWordsApi = undefined
+          if (params.searchInput?.trim()) {
+            // if search input is given, then we should get all words from every semester
+            apiResponse = (
+              await getWordsApi({ searchInput: params.searchInput })
+            )[0]
+          } else {
+            apiResponse = (await getWordsApi(params))[0]
+          }
+          if (!apiResponse) throw new Error(`apiResponse is undefined`)
+
           apiResponse.words.forEach((word) => {
             set(wordsFamily(word.id), word)
           })


### PR DESCRIPTION
# Background
The current Wordnote search is scoped within the selected semester.
This is extremely inconvenient, as users sometimes want to see if they have ever added words.

## TODOs
- [x] Implement Non-semester scoped search

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
Please copy and paste the following into your review, ensuring each checkbox is marked as checked

- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
