### PR TITLE
Search this word button

### DIFF
--- a/src/components/atom_word_card_parts/index.search-this-word.tsx
+++ b/src/components/atom_word_card_parts/index.search-this-word.tsx
@@ -1,0 +1,37 @@
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+import { FC } from 'react'
+import SearchIcon from '@mui/icons-material/Search'
+import { useRecoilCallback, useRecoilValue } from 'recoil'
+import { ISharedWord } from '@/api/words/interfaces'
+import { searchInputState } from '@/recoil/words/searchInput.state'
+interface Props {
+  word: ISharedWord
+}
+const WordCardSearchThisWordButtonPart: FC<Props> = ({ word }) => {
+  const searchInput = useRecoilValue(searchInputState)
+
+  const onClick = useRecoilCallback(
+    ({ set }) =>
+      async () => {
+        // go to the top of page, smoothly
+        window.scrollTo(0, 0)
+        set(searchInputState, word.term.toLowerCase().trim())
+      },
+    [word],
+  )
+
+  return (
+    <StyledIconButtonAtom
+      onClick={onClick}
+      jsxElementButton={<SearchIcon />}
+      hoverMessage={{
+        title: searchInput
+          ? `Already searched with "${searchInput}"`
+          : `Search this word`,
+      }}
+      isDisabled={!!searchInput}
+    />
+  )
+}
+
+export default WordCardSearchThisWordButtonPart

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/recoil/preferences/preference.state'
 import WordCardReviewMode from './index.review_mode'
 import WordCardShareButtonPart from '../atom_word_card_parts/index.share-button'
+import WordCardSearchThisWordButtonPart from '../atom_word_card_parts/index.search-this-word'
 
 interface Props {
   wordId: string
@@ -71,6 +72,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           <WordCardDeleteButton wordId={wordId} />
           {!word.isArchived && <WordCardArchiveButtonPart wordId={wordId} />}
           {word.isArchived && <WordCardUnarchiveButtonPart wordId={wordId} />}
+          <WordCardSearchThisWordButtonPart word={word} />
           <WordCardShareButtonPart wordId={wordId} />
           <TagButtonChunk wordId={wordId} />
           <DictLinkButtonChunk wordId={wordId} />


### PR DESCRIPTION
# Background
Search feature in Wordnote has been drastically improved in https://github.com/ajktown/wordnote/pull/179.
Now users want to search certain word right away without typing.

## TODOs
- [x] https://github.com/ajktown/wordnote/pull/179 is merged
- [x] `git rebase main` is run
- [x] Implement search this word button

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
Please copy and paste the following into your review, ensuring each checkbox is marked as checked

- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled

