### PR TITLE
Consistency Page is now open in beta. Wordnote should suggest users to go

### DIFF
--- a/src/api/action-groups/get-action-groups.api.ts
+++ b/src/api/action-groups/get-action-groups.api.ts
@@ -1,0 +1,28 @@
+import axios from 'axios'
+import { CustomizedAxiosResponse } from '../index.interface'
+
+// ! Since WordnoteGPT only uses isTodayHandled, others are commented out
+// type IActionLevel = 0 | 1 | 2 | 3 | 4
+
+// interface IAction extends DataBasics {
+//   ownerID: string
+//   groupId: string
+//   level: IActionLevel
+//   message: string
+// }
+// export interface ActionGroupProps {
+//   props: IAction
+// }
+export interface GetActionGroupsResDTO {
+  isTodayHandled: boolean
+  // totalCount: number
+  // domains: ActionGroupProps[]
+}
+
+export const getActionGroupsApi = async (): Promise<
+  CustomizedAxiosResponse<GetActionGroupsResDTO>
+> => {
+  const url = `/v1/action-groups`
+  const res = await axios.get(url)
+  return [res.data, res]
+}

--- a/src/components/atom_appbar_parts/index.to_consistency_page_button.tsx
+++ b/src/components/atom_appbar_parts/index.to_consistency_page_button.tsx
@@ -2,18 +2,24 @@ import { FC } from 'react'
 import StyledTextButtonAtom from '@/atoms/StyledTextButton'
 import { useOpenNewTab } from '@/hooks/use-open-new-tab'
 import { envLambda } from '@/lambdas/get-env.lambda'
+import { useRecoilValue } from 'recoil'
+import { isWordPostedDailyState } from '@/recoil/action-groups/action-groups.state'
 
 /** Simply renders a message that the end user is using archive mode.
  * Else, simply returns null, representing it is using normal mode.
  */
 const AppbarToConsistencyPageButtonPart: FC = () => {
   const consistencyPage = envLambda.getConsistencyUrl()
+  const isWordPostedDaily = useRecoilValue(isWordPostedDailyState)
   const onOpenNewTab = useOpenNewTab(consistencyPage)
+
+  if (isWordPostedDaily === null) return null
 
   return (
     <StyledTextButtonAtom
-      title="Go to Consistency Page"
+      title={isWordPostedDaily ? `Well done!` : `Go add word please`}
       onClick={onOpenNewTab}
+      isLoading={isWordPostedDaily === undefined}
     />
   )
 }

--- a/src/components/atom_appbar_parts/index.to_consistency_page_button.tsx
+++ b/src/components/atom_appbar_parts/index.to_consistency_page_button.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react'
+import StyledTextButtonAtom from '@/atoms/StyledTextButton'
+import { useOpenNewTab } from '@/hooks/use-open-new-tab'
+import { envLambda } from '@/lambdas/get-env.lambda'
+
+/** Simply renders a message that the end user is using archive mode.
+ * Else, simply returns null, representing it is using normal mode.
+ */
+const AppbarToConsistencyPageButtonPart: FC = () => {
+  const consistencyPage = envLambda.getConsistencyUrl()
+  const onOpenNewTab = useOpenNewTab(consistencyPage)
+
+  return (
+    <StyledTextButtonAtom
+      title="Go to Consistency Page"
+      onClick={onOpenNewTab}
+    />
+  )
+}
+
+export default AppbarToConsistencyPageButtonPart

--- a/src/components/atom_appbar_parts/index.to_consistency_page_button.tsx
+++ b/src/components/atom_appbar_parts/index.to_consistency_page_button.tsx
@@ -1,11 +1,15 @@
 import { FC } from 'react'
-import StyledTextButtonAtom from '@/atoms/StyledTextButton'
 import { useOpenNewTab } from '@/hooks/use-open-new-tab'
 import { envLambda } from '@/lambdas/get-env.lambda'
 import { useRecoilValue } from 'recoil'
 import { isWordPostedDailyState } from '@/recoil/action-groups/action-groups.state'
+import StyledCircularLoading from '@/atoms/StyledCircularLoading'
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+import WarningAmberIcon from '@mui/icons-material/WarningAmber'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 
-/** Simply renders a message that the end user is using archive mode.
+/**
+ * Simply renders a message that the end user is using archive mode.
  * Else, simply returns null, representing it is using normal mode.
  */
 const AppbarToConsistencyPageButtonPart: FC = () => {
@@ -15,11 +19,28 @@ const AppbarToConsistencyPageButtonPart: FC = () => {
 
   if (isWordPostedDaily === null) return null
 
+  if (isWordPostedDaily === undefined)
+    return <StyledCircularLoading size={20} />
+  if (isWordPostedDaily === false)
+    return (
+      <StyledIconButtonAtom
+        hoverMessage={{
+          title: `You have not posted a word today. Consistency is the key in your success and AJK Town highly recommends to post at least a word daily.`,
+        }}
+        onClick={onOpenNewTab}
+        jsxElementButton={<WarningAmberIcon color="warning" fontSize="small" />}
+      />
+    )
+
   return (
-    <StyledTextButtonAtom
-      title={isWordPostedDaily ? `Well done!` : `Go add word please`}
+    <StyledIconButtonAtom
+      hoverMessage={{
+        title: `You have accomplished posting a daily word. Keep up the good work!`,
+      }}
       onClick={onOpenNewTab}
-      isLoading={isWordPostedDaily === undefined}
+      jsxElementButton={
+        <CheckCircleOutlineIcon color="success" fontSize="small" />
+      }
     />
   )
 }

--- a/src/components/atom_word_cards_frame_parts/index.refresh-button.tsx
+++ b/src/components/atom_word_cards_frame_parts/index.refresh-button.tsx
@@ -2,15 +2,21 @@ import { FC, useCallback } from 'react'
 import StyledCloudRefresher from '@/atoms/StyledCloudRefresher'
 import { usePreference } from '@/hooks/preference/use-preference.hook'
 import { useWordsWithSemesters } from '@/hooks/words/use-words-with-semesters.hook'
+import { useActionGroups } from '@/hooks/action-groups/use-action-groups.hook'
 
 const WordCardsFrameRefreshButtonPart: FC = () => {
   const onGetPreference = usePreference()
   const onGetWordsWithSemesters = useWordsWithSemesters()
+  const onGetActionGroups = useActionGroups()
 
   const onClickRefresh = useCallback(async () => {
     // run all together
-    await Promise.all([onGetWordsWithSemesters(), onGetPreference()])
-  }, [onGetWordsWithSemesters, onGetPreference])
+    await Promise.all([
+      onGetWordsWithSemesters(),
+      onGetPreference(),
+      onGetActionGroups(),
+    ])
+  }, [onGetWordsWithSemesters, onGetPreference, onGetActionGroups])
 
   return <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />
 }

--- a/src/hooks/action-groups/use-action-groups.hook.ts
+++ b/src/hooks/action-groups/use-action-groups.hook.ts
@@ -4,7 +4,7 @@ import { isWordPostedDailyState } from '@/recoil/action-groups/action-groups.sta
 import { useRecoilCallback } from 'recoil'
 
 const NULL_TO_LOADING_SECONDS = 2
-const PRIVATE_LOADING_TO_RESULT_SECONDS = 3
+const PRIVATE_LOADING_TO_RESULT_SECONDS = 1.25
 export const useActionGroups = () => {
   const onGetActionGroups = useRecoilCallback(
     ({ set, snapshot }) =>

--- a/src/hooks/action-groups/use-action-groups.hook.ts
+++ b/src/hooks/action-groups/use-action-groups.hook.ts
@@ -1,0 +1,37 @@
+import { getActionGroupsApi } from '@/api/action-groups/get-action-groups.api'
+import { runAfterHandler } from '@/handlers/run-after.handler'
+import { isWordPostedDailyState } from '@/recoil/action-groups/action-groups.state'
+import { useRecoilCallback } from 'recoil'
+
+const NULL_TO_LOADING_SECONDS = 2
+const PRIVATE_LOADING_TO_RESULT_SECONDS = 3
+export const useActionGroups = () => {
+  const onGetActionGroups = useRecoilCallback(
+    ({ set, snapshot }) =>
+      async () => {
+        try {
+          const [res] = await getActionGroupsApi()
+          const currentStatus = await snapshot.getPromise(
+            isWordPostedDailyState,
+          )
+          if (currentStatus === res.isTodayHandled) return // nothing to change
+
+          runAfterHandler(
+            () => set(isWordPostedDailyState, undefined), // first show that it is being loaded.
+            // run a function that changes the status to the given status from api, after 2 seconds,
+            NULL_TO_LOADING_SECONDS,
+          )
+
+          runAfterHandler(
+            () => set(isWordPostedDailyState, res.isTodayHandled),
+            NULL_TO_LOADING_SECONDS + PRIVATE_LOADING_TO_RESULT_SECONDS,
+          )
+        } catch {
+          set(isWordPostedDailyState, null)
+        }
+      },
+    [],
+  )
+
+  return onGetActionGroups
+}

--- a/src/hooks/words/use-delete-word.hook.ts
+++ b/src/hooks/words/use-delete-word.hook.ts
@@ -2,6 +2,7 @@ import { deleteWordByIdApi } from '@/api/words/delete-words.api'
 import { wordsFamily } from '@/recoil/words/words.state'
 import { useCallback, useState } from 'react'
 import { useRecoilCallback } from 'recoil'
+import { useActionGroups } from '../action-groups/use-action-groups.hook'
 
 type UseDeleteWord = [
   boolean,
@@ -10,6 +11,7 @@ type UseDeleteWord = [
 
 export const useDeleteWord = (deletingWordId: string): UseDeleteWord => {
   const [isDeleting, setDeleting] = useState(false)
+  const onGetActionGroups = useActionGroups()
 
   const setWord = useRecoilCallback(
     ({ snapshot, set }) =>
@@ -32,8 +34,9 @@ export const useDeleteWord = (deletingWordId: string): UseDeleteWord => {
       setWord(deletingWordId)
     } finally {
       setDeleting(false)
+      onGetActionGroups()
     }
-  }, [deletingWordId, setWord])
+  }, [deletingWordId, setWord, onGetActionGroups])
 
   return [isDeleting, onDeleteWord]
 }

--- a/src/hooks/words/use-post-word-from-undo.hook.ts
+++ b/src/hooks/words/use-post-word-from-undo.hook.ts
@@ -13,6 +13,7 @@ type UsePostWordFromUndo = [
   () => Promise<void>, // handlePostWordFromUndo
 ]
 
+// usePostWordFromUndo cannot use usePostWordHook, as it requires different mechanism
 export const usePostWordFromUndo = (
   undoingWordId: string,
 ): UsePostWordFromUndo => {

--- a/src/hooks/words/use-post-word-from-undo.hook.ts
+++ b/src/hooks/words/use-post-word-from-undo.hook.ts
@@ -7,6 +7,7 @@ import {
 import { useRecoilCallback } from 'recoil'
 import { semestersState } from '@/recoil/words/semesters.state'
 import { useState } from 'react'
+import { useActionGroups } from '../action-groups/use-action-groups.hook'
 
 type UsePostWordFromUndo = [
   boolean,
@@ -18,6 +19,7 @@ export const usePostWordFromUndo = (
   undoingWordId: string,
 ): UsePostWordFromUndo => {
   const [loading, setLoading] = useState(false)
+  const onGetActionGroups = useActionGroups()
 
   const onPostWordFromUndo = useRecoilCallback(
     ({ set, snapshot }) =>
@@ -45,9 +47,10 @@ export const usePostWordFromUndo = (
           }
         } finally {
           setLoading(false)
+          onGetActionGroups()
         }
       },
-    [undoingWordId],
+    [undoingWordId, onGetActionGroups],
   )
 
   return [loading, onPostWordFromUndo]

--- a/src/hooks/words/use-post-word.hook.ts
+++ b/src/hooks/words/use-post-word.hook.ts
@@ -3,10 +3,13 @@ import { PostWordReqDto } from '@/api/words/interfaces'
 import { wordIdsState, wordsFamily } from '@/recoil/words/words.state'
 import { useRecoilCallback } from 'recoil'
 import { semestersState } from '@/recoil/words/semesters.state'
+import { useActionGroups } from '../action-groups/use-action-groups.hook'
 
 type UsePostWord = (newWord: PostWordReqDto) => Promise<void> // handlePostWord
 
 export const usePostWord = (): UsePostWord => {
+  const onGetActionGroups = useActionGroups()
+
   const onPostWord = useRecoilCallback(
     ({ set, snapshot }) =>
       async (newWord: PostWordReqDto) => {
@@ -19,9 +22,11 @@ export const usePostWord = (): UsePostWord => {
           set(semestersState, semesters.semesters)
 
           // TODO: Add daysAgo 0 to the latest semester
-        } catch {}
+        } finally {
+          onGetActionGroups()
+        }
       },
-    [],
+    [onGetActionGroups],
   )
 
   return onPostWord

--- a/src/lambdas/axios-request-success.lambda.ts
+++ b/src/lambdas/axios-request-success.lambda.ts
@@ -1,12 +1,13 @@
 import { InternalAxiosRequestConfig } from 'axios'
+import { envLambda } from './get-env.lambda'
 
-const PRIVATE_DEFAULT_API_URL = `https://api.ajktown.com`
+/**
+ * This lambda is used to modify the axios request before it is sent.
+ */
 export const axiosRequestSuccessLambda = (
   config: InternalAxiosRequestConfig<any>,
 ) => {
-  // Do something before request is sent
-  const api_url: string =
-    process.env.NEXT_PUBLIC_API_URL ?? PRIVATE_DEFAULT_API_URL
+  const api_url: string = envLambda.getApiUrl()
 
   config.url = `${api_url}/api` + config.url
   console.log(`Requesting to URL: ` + config.url)

--- a/src/lambdas/get-env.lambda.ts
+++ b/src/lambdas/get-env.lambda.ts
@@ -1,0 +1,23 @@
+enum SupportedEnvAttr {
+  ApiUrl = `NEXT_PUBLIC_API_URL`,
+}
+
+// ! Do not export Strictly imports below. They are only for this file.
+const PRIVATE_DEFAULT_PROD_CONSISTENCY_URL = `https://consistency.ajktown.com`
+const PRIVATE_DEFAULT_API_URL = `https://api.ajktown.com`
+// ! Do not export Strictly imports above. They are only for this file.
+
+export const envLambda = {
+  getApiUrl: () => {
+    return process.env[SupportedEnvAttr.ApiUrl] ?? PRIVATE_DEFAULT_API_URL
+  },
+  mode: {
+    // In Consistency GPT, prod/local is set up based on the API URL.
+    isProduct: () => envLambda.getApiUrl() === PRIVATE_DEFAULT_API_URL,
+    isLocal: () => envLambda.getApiUrl() !== PRIVATE_DEFAULT_API_URL,
+  },
+  getConsistencyUrl: (): string => {
+    if (envLambda.mode.isProduct()) return PRIVATE_DEFAULT_PROD_CONSISTENCY_URL
+    return `http://localhost:3100`
+  },
+}

--- a/src/molecules/StyledAppbar.tsx
+++ b/src/molecules/StyledAppbar.tsx
@@ -7,6 +7,7 @@ import StyledIconButtonAtom from '@/atoms/StyledIconButton'
 import AppbarSearchBar from '@/components/molecule_appbar_search_bar'
 import Image from 'next/image'
 import EndUserAvatar from '@/components/atom_user_avatar/index.end-user'
+import AppbarToConsistencyPageButtonPart from '@/components/atom_appbar_parts/index.to_consistency_page_button'
 
 // TODO: Move this to non-molecules.
 // TODO: Make this getting the children, create a new component Appbar and use it for the pages
@@ -47,6 +48,7 @@ const StyledAppbarMolecule: FC<Props> = ({ onClickAppMenu, ...props }) => {
           <Box pr={2} />
           <AppbarSearchBar />
           <Box flexGrow={1} />
+          <AppbarToConsistencyPageButtonPart />
           <EndUserAvatar />
         </Toolbar>
       </AppBar>

--- a/src/molecules/StyledAppbar.tsx
+++ b/src/molecules/StyledAppbar.tsx
@@ -49,6 +49,7 @@ const StyledAppbarMolecule: FC<Props> = ({ onClickAppMenu, ...props }) => {
           <AppbarSearchBar />
           <Box flexGrow={1} />
           <AppbarToConsistencyPageButtonPart />
+          <Box pr={0.25} />
           <EndUserAvatar />
         </Toolbar>
       </AppBar>

--- a/src/recoil/action-groups/action-groups.state.ts
+++ b/src/recoil/action-groups/action-groups.state.ts
@@ -1,0 +1,16 @@
+import { atom } from 'recoil'
+import { Rkp } from '../index.keys'
+
+/** Private Recoil Key */
+enum Prk {
+  IsWordPostedDaily = `IsWordPostedDaily`,
+}
+
+type PrivateIsWordPostedDailyState =
+  | undefined // it is being loaded (the loading mark should be visible in the UI)
+  | null // nothing is showing.
+  | boolean // if false; should let the user know that daily commitment has not been done
+export const isWordPostedDailyState = atom<PrivateIsWordPostedDailyState>({
+  key: Rkp.App + Prk.IsWordPostedDaily,
+  default: null, // AJK Town prefers undefined as a default value, but this is a special case
+})


### PR DESCRIPTION
# Background
Consistency GPT app is (will be) launched and Wordnote should suggest users of Wordnote to go check out!

Sample:
![image](https://github.com/ajktown/wordnote/assets/53258958/ad8c9093-aba0-4abf-abea-8568fdd7404d)

## TODOs
- [x] Implement API
- [x] Apply the API for the hooks related
  - onPostWords
  - onDeleteWords
  - onPostWordsFromUndo
- [x] Lambda for returning url based on the env

## Checklist (Developers)
- [x] Make this PR as a draft first
- [x] Title is checked
- [x] Background & TODOs are filled
- [x] Assignee is set
- [x] Labels are set
- [x] Project is created & linked, if multiple PRs are associated to this PR
- [x] Appropriate issue(s) is(are) linked to this PR under `development`
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
