### PR TITLE
Shared Word Page now let users to download the word if signed in

### DIFF
--- a/src/atoms/StyledIconButtonNewPage.tsx
+++ b/src/atoms/StyledIconButtonNewPage.tsx
@@ -1,0 +1,27 @@
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+import { FC } from 'react'
+import LaunchIcon from '@mui/icons-material/Launch'
+import { useOpenNewTab } from '@/hooks/use-open-new-tab'
+interface Props {
+  link: string
+  hoverMessage?: string
+  disabled?: boolean
+}
+const StyledIconButtonNewPage: FC<Props> = ({
+  link,
+  hoverMessage,
+  disabled,
+}) => {
+  const onClick = useOpenNewTab(link)
+
+  return (
+    <StyledIconButtonAtom
+      isDisabled={disabled}
+      onClick={onClick}
+      jsxElementButton={<LaunchIcon />}
+      hoverMessage={{ title: hoverMessage ?? `` }}
+    />
+  )
+}
+
+export default StyledIconButtonNewPage

--- a/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
+++ b/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
@@ -9,8 +9,7 @@ interface Props {
 }
 const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
   const sharedWord = useRecoilValue(sharedWordFamily(wordId))
-  const onPostWord = usePostWord()
-  const [loading, setLoading] = useState(false)
+  const [loading, onPostWord] = usePostWord()
   const [isAdded, setAdded] = useState(false)
 
   const onClick = useCallback(async () => {
@@ -18,7 +17,6 @@ const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
       if (!sharedWord) return
       if (!sharedWord.word) return
 
-      setLoading(true)
       await onPostWord({
         isFavorite: false,
         isArchived: false,
@@ -32,9 +30,7 @@ const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
 
       // since it is added, it should be already added.
       setAdded(true)
-    } finally {
-      setLoading(false)
-    }
+    } catch {}
   }, [sharedWord, onPostWord])
 
   if (isAdded)

--- a/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
+++ b/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
@@ -1,5 +1,6 @@
 import StyledTextButtonAtom from '@/atoms/StyledTextButton'
 import { usePostWord } from '@/hooks/words/use-post-word.hook'
+import { isSignedInSelector } from '@/recoil/app/app.selectors'
 import { sharedWordFamily } from '@/recoil/shared-resource/shared-resource.state'
 import { FC, useCallback, useState } from 'react'
 import { useRecoilValue } from 'recoil'
@@ -11,6 +12,7 @@ const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
   const sharedWord = useRecoilValue(sharedWordFamily(wordId))
   const [loading, onPostWord] = usePostWord()
   const [isAdded, setAdded] = useState(false)
+  const isSignedIn = useRecoilValue(isSignedInSelector)
 
   const onClick = useCallback(async () => {
     try {
@@ -32,6 +34,9 @@ const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
       setAdded(true)
     } catch {}
   }, [sharedWord, onPostWord])
+
+  if (!isSignedIn)
+    return <StyledTextButtonAtom isDisabled title={`Sign in to add`} />
 
   if (isAdded)
     return <StyledTextButtonAtom isDisabled title={`Already added`} />

--- a/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
+++ b/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
@@ -1,7 +1,10 @@
+import StyledIconButtonNewPage from '@/atoms/StyledIconButtonNewPage'
 import StyledTextButtonAtom from '@/atoms/StyledTextButton'
+import { PageConst } from '@/constants/pages.constant'
 import { usePostWord } from '@/hooks/words/use-post-word.hook'
 import { isSignedInSelector } from '@/recoil/app/app.selectors'
 import { sharedWordFamily } from '@/recoil/shared-resource/shared-resource.state'
+import { Stack } from '@mui/material'
 import { FC, useCallback, useState } from 'react'
 import { useRecoilValue } from 'recoil'
 
@@ -36,7 +39,15 @@ const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
   }, [sharedWord, onPostWord])
 
   if (!isSignedIn)
-    return <StyledTextButtonAtom isDisabled title={`Sign in to add`} />
+    return (
+      <Stack alignItems="center" direction="row">
+        <StyledTextButtonAtom isDisabled title={`Sign in to add this word in your list`} />
+        <StyledIconButtonNewPage
+          link={PageConst.Welcome}
+          hoverMessage="To sign in page"
+        />
+      </Stack>
+    )
 
   if (isAdded)
     return <StyledTextButtonAtom isDisabled title={`Already added`} />

--- a/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
+++ b/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
@@ -41,7 +41,10 @@ const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
   if (!isSignedIn)
     return (
       <Stack alignItems="center" direction="row">
-        <StyledTextButtonAtom isDisabled title={`Sign in to add this word in your list`} />
+        <StyledTextButtonAtom
+          isDisabled
+          title={`Sign in to add this word in your list`}
+        />
         <StyledIconButtonNewPage
           link={PageConst.Welcome}
           hoverMessage="To sign in page"

--- a/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
+++ b/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
@@ -1,0 +1,13 @@
+import StyledTextButtonAtom from '@/atoms/StyledTextButton'
+import { FC } from 'react'
+
+interface Props {
+  wordId: string
+}
+const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
+  return (
+    <StyledTextButtonAtom title={`Add this word into your list` + wordId} />
+  )
+}
+
+export default SharedWordCardAddWordButtonPart

--- a/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
+++ b/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
@@ -1,12 +1,52 @@
 import StyledTextButtonAtom from '@/atoms/StyledTextButton'
-import { FC } from 'react'
+import { usePostWord } from '@/hooks/words/use-post-word.hook'
+import { sharedWordFamily } from '@/recoil/shared-resource/shared-resource.state'
+import { FC, useCallback, useState } from 'react'
+import { useRecoilValue } from 'recoil'
 
 interface Props {
   wordId: string
 }
 const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
+  const sharedWord = useRecoilValue(sharedWordFamily(wordId))
+  const onPostWord = usePostWord()
+  const [loading, setLoading] = useState(false)
+  const [isAdded, setAdded] = useState(false)
+
+  const onClick = useCallback(async () => {
+    try {
+      if (!sharedWord) return
+      if (!sharedWord.word) return
+
+      setLoading(true)
+      await onPostWord({
+        isFavorite: false,
+        isArchived: false,
+        term: sharedWord.word.term,
+        pronunciation: sharedWord.word.pronunciation,
+        definition: sharedWord.word.definition,
+        example: sharedWord.word?.example,
+        exampleLink: ``,
+        tags: [],
+      })
+
+      // since it is added, it should be already added.
+      setAdded(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [sharedWord, onPostWord])
+
+  if (isAdded)
+    return <StyledTextButtonAtom isDisabled title={`Already added`} />
+
   return (
-    <StyledTextButtonAtom title={`Add this word into your list` + wordId} />
+    <StyledTextButtonAtom
+      onClick={onClick}
+      isLoading={loading}
+      isDisabled={!sharedWord?.word}
+      title={`Add this word into your list`}
+    />
   )
 }
 

--- a/src/hooks/app/use-is-app-booted.hook.ts
+++ b/src/hooks/app/use-is-app-booted.hook.ts
@@ -14,6 +14,7 @@ export const useIsAppBooted = (): boolean => {
 
   const onAppBooting = useCallback(async () => {
     try {
+      // TODO: Use const isSignedIn = useRecoilValue(isSignedInSelector) instead
       const isSignedIn = (await onGetAuthPrep())?.isSignedIn
 
       // The page share does not require sign in. But it should get the auth prep data just in case.

--- a/src/pages/share/index.tsx
+++ b/src/pages/share/index.tsx
@@ -1,8 +1,9 @@
+import SharedWordCardAddWordButtonPart from '@/components/atom_shared_word_card_parts/index.add-word-button'
 import WordCardShared from '@/components/molecule_word_card/index.shared'
 import { PageQueryConst } from '@/constants/page-queries.constant'
 import { useSharedResource } from '@/hooks/shared-resources/use-shared-resource.hook'
 import StyledCentered from '@/organisms/StyledCentered'
-import { Stack, Typography } from '@mui/material'
+import { Box, Stack, Typography } from '@mui/material'
 import { useRouter } from 'next/router'
 import { FC, useEffect } from 'react'
 
@@ -29,6 +30,8 @@ const SharePage: FC = () => {
       <Stack minWidth={700}>
         <WordCardShared wordId={wordId.trim()} />
       </Stack>
+      <Box mb={1} />
+      <SharedWordCardAddWordButtonPart wordId={wordId.trim()} />
     </StyledCentered>
   )
 }


### PR DESCRIPTION
# Background
Implement a button for the shared page to add a certain word right away

If Not Signed in:
![image](https://github.com/ajktown/wordnote/assets/53258958/5da8883e-55a9-456b-b8de-bd42534deeb6)

If Signed in:
![image](https://github.com/ajktown/wordnote/assets/53258958/aeff89ee-321f-48c8-ae47-6e9020370c99)

If signed in and already added:
![image](https://github.com/ajktown/wordnote/assets/53258958/21f54a1b-26eb-47f5-8a91-e3ddd8d05658)



## TODOs
- [x] If signed in: User can click a button to copy the word
- [x] If not signed in: the post button is disabled and tell that you are not signed in

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
