### PR TITLE
Refactor usePostWord with returned value isLoading

### DIFF
--- a/src/components/organism_word_card_chunk/index.search_not_found.tsx
+++ b/src/components/organism_word_card_chunk/index.search_not_found.tsx
@@ -11,7 +11,7 @@ const WordCardChunkSearchNotFound: FC = () => {
   const searchInput = useRecoilValue(searchInputState)
   const [, onResetSearchInput] = useResetSearchInput()
   const setSearchInput = useSetRecoilState(searchInputState)
-  const onPostWord = usePostWord()
+  const [, onPostWord] = usePostWord()
 
   const handleClickPostWord = useCallback(() => {
     const parsed = parseInputIntoWordLambda(searchInput)

--- a/src/hooks/words/use-post-word-with-string.hook.ts
+++ b/src/hooks/words/use-post-word-with-string.hook.ts
@@ -15,7 +15,7 @@ type UsePostWordWithStringHook = [
 ]
 
 export const usePostWordWithStringHook = (): UsePostWordWithStringHook => {
-  const onPostWord = usePostWord()
+  const [, onPostWord] = usePostWord()
   const [userInput, setUserInput] = useState(``)
   const [loading, setLoading] = useState(false)
   const [isWritingMode, setWritingMode] = useState(false)

--- a/src/hooks/words/use-post-word.hook.ts
+++ b/src/hooks/words/use-post-word.hook.ts
@@ -4,16 +4,22 @@ import { wordIdsState, wordsFamily } from '@/recoil/words/words.state'
 import { useRecoilCallback } from 'recoil'
 import { semestersState } from '@/recoil/words/semesters.state'
 import { useActionGroupDailyPostWordChallengeApi } from '../action-groups/use-action-group-daily-post-word-challenge.api'
+import { useState } from 'react'
 
-type UsePostWord = (newWord: PostWordReqDto) => Promise<void> // handlePostWord
+type UsePostWord = [
+  boolean,
+  (newWord: PostWordReqDto) => Promise<void>, // handlePostWord
+]
 
 export const usePostWord = (): UsePostWord => {
+  const [loading, setLoading] = useState(false)
   const onGetActionGroups = useActionGroupDailyPostWordChallengeApi()
 
   const onPostWord = useRecoilCallback(
     ({ set, snapshot }) =>
       async (newWord: PostWordReqDto) => {
         try {
+          setLoading(true)
           const [{ postedWord, semesters }] = await postWordApi(newWord)
 
           const wordIds = await snapshot.getPromise(wordIdsState)
@@ -23,11 +29,12 @@ export const usePostWord = (): UsePostWord => {
 
           // TODO: Add daysAgo 0 to the latest semester
         } finally {
+          setLoading(false)
           onGetActionGroups()
         }
       },
     [onGetActionGroups],
   )
 
-  return onPostWord
+  return [loading, onPostWord]
 }


### PR DESCRIPTION
# Background
https://github.com/ajktown/wordnote/issues/190

## TODOs
- [x] Make `usePostWord` to return isLoading state too

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
