### PR TITLE
Search dialog openable in WordCard

### DIFF
--- a/src/components/atom_word_card_parts/index.search-this-word.tsx
+++ b/src/components/atom_word_card_parts/index.search-this-word.tsx
@@ -1,23 +1,18 @@
 import StyledIconButtonAtom from '@/atoms/StyledIconButton'
 import { FC } from 'react'
 import SearchIcon from '@mui/icons-material/Search'
-import { useRecoilCallback, useRecoilValue } from 'recoil'
-import { ISharedWord } from '@/api/words/interfaces'
-import { searchInputState } from '@/recoil/words/searchInput.state'
+import { useRecoilCallback } from 'recoil'
+import { searchByWordIdState } from '@/recoil/words/searchInput.state'
 interface Props {
-  word: ISharedWord
+  wordId: string
 }
-const WordCardSearchThisWordButtonPart: FC<Props> = ({ word }) => {
-  const searchInput = useRecoilValue(searchInputState)
-
+const WordCardSearchThisWordButtonPart: FC<Props> = ({ wordId }) => {
   const onClick = useRecoilCallback(
     ({ set }) =>
-      async () => {
-        // go to the top of page, smoothly
-        window.scrollTo(0, 0)
-        set(searchInputState, word.term.toLowerCase().trim())
+      () => {
+        set(searchByWordIdState, wordId)
       },
-    [word],
+    [wordId],
   )
 
   return (
@@ -25,11 +20,8 @@ const WordCardSearchThisWordButtonPart: FC<Props> = ({ word }) => {
       onClick={onClick}
       jsxElementButton={<SearchIcon />}
       hoverMessage={{
-        title: searchInput
-          ? `Already searched with "${searchInput}"`
-          : `Search this word`,
+        title: `Open Search Dialog with this word`,
       }}
-      isDisabled={!!searchInput}
     />
   )
 }

--- a/src/components/molecule_tag_button_chunk/index.tsx
+++ b/src/components/molecule_tag_button_chunk/index.tsx
@@ -1,20 +1,15 @@
-import { wordsFamily } from '@/recoil/words/words.state'
 import { Stack } from '@mui/material'
 import { FC } from 'react'
-import { useRecoilValue } from 'recoil'
 import TagChipCustomized from '../atom_tag_chip/index.customized'
 import TagChipLanguage from '../atom_tag_chip/index.language'
 import TagChipSemesterCode from '../atom_tag_chip/index.semester-code'
+import { WordData } from '@/api/words/interfaces'
 
 interface Props {
-  wordId: string
+  word: WordData
   clickDisabled?: boolean
 }
-const TagButtonChunk: FC<Props> = ({ wordId, clickDisabled }) => {
-  const word = useRecoilValue(wordsFamily(wordId))
-
-  if (word == null) return null
-
+const TagButtonChunk: FC<Props> = ({ word, clickDisabled }) => {
   return (
     <Stack
       direction="row"

--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -12,6 +12,7 @@ import WordCardArchiveButtonPart from '../atom_word_card_parts/index.archive-but
 import WordCardUnarchiveButtonPart from '../atom_word_card_parts/index.unarchive-button'
 import WordCardShareButtonPart from '../atom_word_card_parts/index.share-button'
 import DictLinkButtonChunk from '../molecule_dict_link_button_chunk'
+import WordCardSearchThisWordButtonPart from '../atom_word_card_parts/index.search-this-word'
 interface Props {
   word: WordData
 }
@@ -52,13 +53,16 @@ const WordCardReviewMode: FC<Props> = ({ word }) => {
             visibleHoverMessage={`Peek this word card`}
           />
           {isPeekMode && !word.isArchived && (
+            // because it kind of does not make sense to archive/unarchive when you cannot fully see the word card
             <WordCardArchiveButtonPart wordId={word.id} />
           )}
           {isPeekMode && word.isArchived && (
+            // because it kind of does not make sense to archive/unarchive when you cannot fully see the word card
             <WordCardUnarchiveButtonPart wordId={word.id} />
           )}
-          {isPeekMode && <WordCardShareButtonPart wordId={word.id} />}
-          <TagButtonChunk wordId={word.id} />
+          <WordCardSearchThisWordButtonPart wordId={word.id} />
+          <WordCardShareButtonPart wordId={word.id} />
+          <TagButtonChunk word={word} />
           <DictLinkButtonChunk wordId={word.id} />
         </CardActions>
       </Card>

--- a/src/components/molecule_word_card/index.search_dialog.tsx
+++ b/src/components/molecule_word_card/index.search_dialog.tsx
@@ -1,0 +1,93 @@
+import { FC, useEffect } from 'react'
+import StyledDialog from '@/organisms/StyledDialog'
+import { useRecoilCallback, useRecoilValue } from 'recoil'
+import {
+  searchByWordIdState,
+  searchedWordsByWordIdState,
+} from '@/recoil/words/searchInput.state'
+import WordCardsChunkNoWordsFound from '../organism_word_card_chunk/index.no_words_found'
+import {
+  Card,
+  CardActions,
+  CardContent,
+  DialogContent,
+  Stack,
+  Typography,
+} from '@mui/material'
+import StyledSuspense from '@/organisms/StyledSuspense'
+import WordCardExamplePart from '../atom_word_card_parts/index.example'
+import { useSearchedWordsByWordId } from '@/hooks/words/use-searched-words-by-word-id.hook'
+import TagButtonChunk from '../molecule_tag_button_chunk'
+
+const WordCardSearchDialog: FC = () => {
+  const searchingWordId = useRecoilValue(searchByWordIdState)
+  const words = useRecoilValue(searchedWordsByWordIdState)
+  const onGetSearchedWordsByWordId = useSearchedWordsByWordId(searchingWordId)
+
+  const onClose = useRecoilCallback(
+    ({ reset }) =>
+      () => {
+        reset(searchByWordIdState)
+        reset(searchedWordsByWordIdState)
+      },
+    [],
+  )
+
+  // run onGetSearchedWordsByWordId
+  useEffect(() => {
+    onGetSearchedWordsByWordId()
+  }, [onGetSearchedWordsByWordId])
+
+  if (!searchingWordId) return null // dialog is not open
+  if (words === undefined)
+    return (
+      <StyledDialog onClose={onClose}>
+        <p>Loading...</p>
+      </StyledDialog>
+    )
+
+  if (words === null)
+    return (
+      <StyledDialog onClose={onClose}>
+        <p>Failed to load</p>
+      </StyledDialog>
+    )
+
+  if (words.length === 0) return <WordCardsChunkNoWordsFound />
+
+  return (
+    <StyledDialog onClose={onClose}>
+      <DialogContent>
+        <Stack spacing={1} alignItems={`center`}>
+          <Typography variant="caption">
+            {words.length} {words.length === 1 ? `word card` : `word cards`}
+          </Typography>
+          {words.map((word) => (
+            <StyledSuspense key={word.id}>
+              <Card style={{ width: `100%`, borderRadius: 9 }}>
+                <CardContent>
+                  <Typography variant="h5" component="div">
+                    {word.term}
+                  </Typography>
+                  <Typography sx={{ mb: 1.5 }} color="text.secondary">
+                    {word.pronunciation}
+                  </Typography>
+                  <Typography variant="body2">
+                    {word.definition}
+                    <br />
+                  </Typography>
+                  <WordCardExamplePart word={word} />
+                </CardContent>
+                <CardActions>
+                  <TagButtonChunk word={word} clickDisabled />
+                </CardActions>
+              </Card>
+            </StyledSuspense>
+          ))}
+        </Stack>
+      </DialogContent>
+    </StyledDialog>
+  )
+}
+
+export default WordCardSearchDialog

--- a/src/components/molecule_word_card/index.search_dialog.tsx
+++ b/src/components/molecule_word_card/index.search_dialog.tsx
@@ -3,6 +3,7 @@ import StyledDialog from '@/organisms/StyledDialog'
 import { useRecoilCallback, useRecoilValue } from 'recoil'
 import {
   searchByWordIdState,
+  searchInputState,
   searchedWordsByWordIdState,
 } from '@/recoil/words/searchInput.state'
 import WordCardsChunkNoWordsFound from '../organism_word_card_chunk/index.no_words_found'
@@ -18,6 +19,8 @@ import StyledSuspense from '@/organisms/StyledSuspense'
 import WordCardExamplePart from '../atom_word_card_parts/index.example'
 import { useSearchedWordsByWordId } from '@/hooks/words/use-searched-words-by-word-id.hook'
 import TagButtonChunk from '../molecule_tag_button_chunk'
+import StyledTextButtonAtom from '@/atoms/StyledTextButton'
+import { wordsFamily } from '@/recoil/words/words.state'
 
 const WordCardSearchDialog: FC = () => {
   const searchingWordId = useRecoilValue(searchByWordIdState)
@@ -31,6 +34,24 @@ const WordCardSearchDialog: FC = () => {
         reset(searchedWordsByWordIdState)
       },
     [],
+  )
+
+  const onClickOpenMainSearch = useRecoilCallback(
+    ({ set, snapshot }) =>
+      async () => {
+        if (!searchingWordId) return // fatal error; but no error yet
+
+        // get word:
+        const word = await snapshot.getPromise(wordsFamily(searchingWordId))
+        if (!word) return // fatal error; but no error yet
+
+        // set word:
+        set(searchInputState, word.term)
+
+        // finally:
+        onClose()
+      },
+    [searchingWordId, onClose],
   )
 
   // run onGetSearchedWordsByWordId
@@ -62,6 +83,10 @@ const WordCardSearchDialog: FC = () => {
           <Typography variant="caption">
             {words.length} {words.length === 1 ? `word card` : `word cards`}
           </Typography>
+          <StyledTextButtonAtom
+            title="Open main search for this word instead"
+            onClick={onClickOpenMainSearch}
+          />
           {words.map((word) => (
             <StyledSuspense key={word.id}>
               <Card style={{ width: `100%`, borderRadius: 9 }}>

--- a/src/components/molecule_word_card/index.share-review.tsx
+++ b/src/components/molecule_word_card/index.share-review.tsx
@@ -35,7 +35,7 @@ const WordCardShareReview: FC<Props> = ({ wordId }) => {
           <WordCardExamplePart word={shareReviewWord} />
         </CardContent>
         <CardActions>
-          <TagButtonChunk wordId={wordId} clickDisabled />
+          <TagButtonChunk word={shareReviewWord} clickDisabled />
         </CardActions>
       </Card>
     </StyledSuspense>

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -72,9 +72,9 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           <WordCardDeleteButton wordId={wordId} />
           {!word.isArchived && <WordCardArchiveButtonPart wordId={wordId} />}
           {word.isArchived && <WordCardUnarchiveButtonPart wordId={wordId} />}
-          <WordCardSearchThisWordButtonPart word={word} />
+          <WordCardSearchThisWordButtonPart wordId={wordId} />
           <WordCardShareButtonPart wordId={wordId} />
-          <TagButtonChunk wordId={wordId} />
+          <TagButtonChunk word={word} />
           <DictLinkButtonChunk wordId={wordId} />
         </CardActions>
       </Card>

--- a/src/components/organism_word_card_frame/index.tsx
+++ b/src/components/organism_word_card_frame/index.tsx
@@ -13,6 +13,7 @@ import WordCardsFrameArchiveSwitchPart from '../atom_word_cards_frame_parts/inde
 import WordCardsFrameArchiveModePart from '../atom_word_cards_frame_parts/index.archive-mode'
 import SharedResourceDialog from '../dialog_shared_resource'
 import WordCardsFrameReviewModePart from '../atom_word_cards_frame_parts/index.review-mode'
+import WordCardSearchDialog from '../molecule_word_card/index.search_dialog'
 
 const WordCardFrame: FC = () => {
   return (
@@ -40,6 +41,7 @@ const WordCardFrame: FC = () => {
         {/* Dialog */}
         <WordCardDialog />
         <SharedResourceDialog />
+        <WordCardSearchDialog />
       </Stack>
     </Stack>
   )

--- a/src/hooks/words/use-searched-words-by-word-id.hook.ts
+++ b/src/hooks/words/use-searched-words-by-word-id.hook.ts
@@ -1,0 +1,31 @@
+import { useRecoilCallback } from 'recoil'
+import { getWordsApi } from '@/api/words/get-words.api'
+import { wordsFamily } from '@/recoil/words/words.state'
+import { searchedWordsByWordIdState } from '@/recoil/words/searchInput.state'
+
+/**
+ * useSearchedWordsByWordId search words based on the information of word id
+ * and store it in a recoil state separate from the main word state.
+ * this way users can search for words without affecting the main word state.
+ */
+export const useSearchedWordsByWordId = (wordId: string) => {
+  const onGetSearchedWordsByWordId = useRecoilCallback(
+    ({ snapshot, set }) =>
+      async () => {
+        try {
+          if (!wordId) return // empty wordId
+
+          const word = await snapshot.getPromise(wordsFamily(wordId))
+          if (!word) return // no such word found. cannot search
+
+          const [data] = await getWordsApi({ searchInput: word.term })
+          set(searchedWordsByWordIdState, data.words)
+        } catch {
+          set(searchedWordsByWordIdState, null)
+        }
+      },
+    [wordId],
+  )
+
+  return onGetSearchedWordsByWordId
+}

--- a/src/recoil/words/searchInput.state.ts
+++ b/src/recoil/words/searchInput.state.ts
@@ -1,10 +1,33 @@
 import { atom } from 'recoil'
 import { Rkp } from '../index.keys'
+import { WordData } from '@/api/words/interfaces'
 
 /** Private Recoil Key */
 // enum Prk {} // No Private Recoil Key at this point
 
+/** Private Recoil Key */
+enum Prk {
+  SearchInputState = `SearchInputState`,
+  SearchByWordIdState = `SearchByWordIdState`,
+  SearchedWordsByWordIdState = `SearchedWordsByWordIdState`,
+}
+
 export const searchInputState = atom<string>({
-  key: Rkp.SearchInput,
+  key: Rkp.SearchInput + Prk.SearchInputState,
   default: ``,
 })
+
+export const searchByWordIdState = atom<string>({
+  key: Rkp.SearchInput + Prk.SearchByWordIdState,
+  default: ``,
+})
+
+type PrivateSearchedWordsByWordIdState =
+  | undefined // loading
+  | null // failed to load; something went wrong
+  | WordData[]
+export const searchedWordsByWordIdState =
+  atom<PrivateSearchedWordsByWordIdState>({
+    key: Rkp.SearchInput + Prk.SearchedWordsByWordIdState,
+    default: undefined,
+  })


### PR DESCRIPTION
# Background
Search button in the WordCard now will open a dialog instead with the search results.
You can also see the full results if you want to edit it. (Ideally it is great to be able to modify too, but decide not to)

![image](https://github.com/ajktown/wordnote/assets/53258958/488ed58d-5e82-43df-be64-767be3aad43a)


## TODOs
- [x] Implement a dialog for the search so that the current main view does not get modified

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
