### PR TITLE
EnterKey bug on conversion

### DIFF
--- a/src/hooks/use-key-press.hook.ts
+++ b/src/hooks/use-key-press.hook.ts
@@ -8,7 +8,7 @@ export const useKeyPress = (
 ) => {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== keyName) return
+      if (event.isComposing || event.key !== keyName) return
 
       event.preventDefault()
       onKeyPress()


### PR DESCRIPTION
# Background
https://github.com/ajktown/wordnote/issues/188

## TODOs
- [x] TODO: fix the Enter key bug on conversion

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
