### PR TITLE
Dictionary icons not visible when window width not big enough (smartphone screens)

### DIFF
--- a/src/components/molecule_dict_link_button_chunk/index.tsx
+++ b/src/components/molecule_dict_link_button_chunk/index.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment } from 'react'
+import { FC } from 'react'
 import KoNaverDictionaryLinkButton from './ko-naver.dict-link-button'
 import EnKoNaverDictionaryLinkButton from './en-ko.dict-link-button'
 import ZhKoNaverDictionaryLinkButton from './zh-ko-naver.dict-link-button'
@@ -8,13 +8,14 @@ import EnUrbanDictionaryDictLinkButton from './en-urban-dictionary.dict-link-but
 import AllLangsGoogleDictLinkButton from './all-langs-google.dict-link-button'
 import KoJaNaverDictionaryLinkButton from './ko-ja-naver.dict-link-button'
 import JaEnDeeplDictLinkButton from './ja-en-deepl.dict-link-button'
+import { Stack } from '@mui/material'
 
 interface Props {
   wordId: string
 }
 const DictLinkButtonChunk: FC<Props> = ({ wordId }) => {
   return (
-    <Fragment>
+    <Stack direction={`row`} alignItems={`center`}>
       <AllLangsGoogleDictLinkButton wordId={wordId} />
       <KoNaverDictionaryLinkButton wordId={wordId} />
       <EnKoNaverDictionaryLinkButton wordId={wordId} />
@@ -24,7 +25,7 @@ const DictLinkButtonChunk: FC<Props> = ({ wordId }) => {
       <EnDictionaryDotComDictLinkButton wordId={wordId} />
       <EnUrbanDictionaryDictLinkButton wordId={wordId} />
       <JaEnDeeplDictLinkButton wordId={wordId} />
-    </Fragment>
+    </Stack>
   )
 }
 

--- a/src/components/molecule_tag_button_chunk/index.tsx
+++ b/src/components/molecule_tag_button_chunk/index.tsx
@@ -12,6 +12,7 @@ interface Props {
 const TagButtonChunk: FC<Props> = ({ word, clickDisabled }) => {
   return (
     <Stack
+      alignItems={`center`}
       direction="row"
       spacing={0.2}
       sx={{ flexWrap: `wrap`, rowGap: `3px` }}

--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -1,5 +1,11 @@
 import { FC, useState } from 'react'
-import { Card, CardActions, CardContent, Typography } from '@mui/material'
+import {
+  Card,
+  CardActions,
+  CardContent,
+  Stack,
+  Typography,
+} from '@mui/material'
 import WordCardFavoriteIcon from '../atom_word_card_favorite_icon'
 import StyledSuspense from '@/organisms/StyledSuspense'
 import { WordData } from '@/api/words/interfaces'
@@ -13,6 +19,7 @@ import WordCardUnarchiveButtonPart from '../atom_word_card_parts/index.unarchive
 import WordCardShareButtonPart from '../atom_word_card_parts/index.share-button'
 import DictLinkButtonChunk from '../molecule_dict_link_button_chunk'
 import WordCardSearchThisWordButtonPart from '../atom_word_card_parts/index.search-this-word'
+import { useWindowSize } from 'react-use'
 interface Props {
   word: WordData
 }
@@ -20,6 +27,7 @@ interface Props {
 const WordCardReviewMode: FC<Props> = ({ word }) => {
   const { id } = word
   const [isPeekMode, setPeekMode] = useState(false)
+  const { width } = useWindowSize()
 
   const onClickWordCard = useRecoilCallback(
     ({ set }) =>
@@ -46,24 +54,33 @@ const WordCardReviewMode: FC<Props> = ({ word }) => {
           <WordCardExamplePart word={word} reviewMode={!isPeekMode} />
         </CardContent>
         <CardActions>
-          <WordCardFavoriteIcon wordId={word.id} />
-          <StyledVisibilityAtom
-            isVisible={!isPeekMode}
-            onClick={() => setPeekMode(!isPeekMode)}
-            visibleHoverMessage={`Peek this word card`}
-          />
-          {isPeekMode && !word.isArchived && (
-            // because it kind of does not make sense to archive/unarchive when you cannot fully see the word card
-            <WordCardArchiveButtonPart wordId={word.id} />
-          )}
-          {isPeekMode && word.isArchived && (
-            // because it kind of does not make sense to archive/unarchive when you cannot fully see the word card
-            <WordCardUnarchiveButtonPart wordId={word.id} />
-          )}
-          <WordCardSearchThisWordButtonPart wordId={word.id} />
-          <WordCardShareButtonPart wordId={word.id} />
-          <TagButtonChunk word={word} />
-          <DictLinkButtonChunk wordId={word.id} />
+          <Stack direction={width > 622 ? `row` : `column`} alignItems={`left`}>
+            <Stack
+              direction={width > 440 ? `row` : `column`}
+              alignItems={`left`}
+            >
+              <Stack direction={`row`} alignItems={`center`}>
+                <WordCardFavoriteIcon wordId={word.id} />
+                <StyledVisibilityAtom
+                  isVisible={!isPeekMode}
+                  onClick={() => setPeekMode(!isPeekMode)}
+                  visibleHoverMessage={`Peek this word card`}
+                />
+                {isPeekMode && !word.isArchived && (
+                  // because it kind of does not make sense to archive/unarchive when you cannot fully see the word card
+                  <WordCardArchiveButtonPart wordId={word.id} />
+                )}
+                {isPeekMode && word.isArchived && (
+                  // because it kind of does not make sense to archive/unarchive when you cannot fully see the word card
+                  <WordCardUnarchiveButtonPart wordId={word.id} />
+                )}
+                <WordCardSearchThisWordButtonPart wordId={word.id} />
+                <WordCardShareButtonPart wordId={word.id} />
+              </Stack>
+              <TagButtonChunk word={word} />
+            </Stack>
+            <DictLinkButtonChunk wordId={word.id} />
+          </Stack>
         </CardActions>
       </Card>
     </StyledSuspense>

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -67,7 +67,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           </Typography>
           <WordCardExamplePart word={word} />
         </CardContent>
-        <CardActions className="custom-card-actions">
+        <CardActions>
           <WordCardFavoriteIcon wordId={wordId} />
           <WordCardDeleteButton wordId={wordId} />
           {!word.isArchived && <WordCardArchiveButtonPart wordId={wordId} />}
@@ -75,9 +75,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           <WordCardSearchThisWordButtonPart wordId={wordId} />
           <WordCardShareButtonPart wordId={wordId} />
           <TagButtonChunk word={word} />
-          <div className="dict-link-container">
-            <DictLinkButtonChunk wordId={wordId} />
-          </div>
+          <DictLinkButtonChunk wordId={wordId} />
         </CardActions>
       </Card>
     </StyledSuspense>

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -1,5 +1,11 @@
 import { FC } from 'react'
-import { Box, Card, CardActions, CardContent, Typography } from '@mui/material'
+import {
+  Card,
+  CardActions,
+  CardContent,
+  Stack,
+  Typography,
+} from '@mui/material'
 import WordCardFavoriteIcon from '../atom_word_card_favorite_icon'
 import WordCardDeleteButton from '../atom_word_card_delete_button'
 import WordCardDeleted from './index.deleted'
@@ -24,12 +30,14 @@ import {
 import WordCardReviewMode from './index.review_mode'
 import WordCardShareButtonPart from '../atom_word_card_parts/index.share-button'
 import WordCardSearchThisWordButtonPart from '../atom_word_card_parts/index.search-this-word'
+import { useWindowSize } from 'react-use'
 
 interface Props {
   wordId: string
   editingMode?: boolean
 }
 const WordCard: FC<Props> = ({ wordId, editingMode }) => {
+  const { width } = useWindowSize()
   const word = useRecoilValue(wordsFamily(wordId))
   const isShowingArchived = useRecoilValue(isShowingArchivedState)
 
@@ -67,39 +75,28 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           </Typography>
           <WordCardExamplePart word={word} />
         </CardContent>
-        <CardActions
-          sx={{
-            display: `flex`,
-            flexDirection: { xs: `column`, sm: `row` },
-            alignItems: `flex-start`,
-            flexWrap: 'wrap', 
-          }}
-        >
-          <Box
-            sx={{
-              display: `flex`,
-              flexDirection: 'row', 
-              flexWrap: `wrap`,
-              width: { xs: `100%`, sm: `auto` },
-              alignItems: `center`,
-            }}
-          >
-            <WordCardFavoriteIcon wordId={wordId} />
-            <WordCardDeleteButton wordId={wordId} />
-            {!word.isArchived && <WordCardArchiveButtonPart wordId={wordId} />}
-            {word.isArchived && <WordCardUnarchiveButtonPart wordId={wordId} />}
-            <WordCardSearchThisWordButtonPart wordId={wordId} />
-            <WordCardShareButtonPart wordId={wordId} />
-            <TagButtonChunk word={word} />
-          </Box>
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: `row`,
-            }}
-          >
+        <CardActions>
+          <Stack direction={width > 622 ? `row` : `column`} alignItems={`left`}>
+            <Stack
+              direction={width > 440 ? `row` : `column`}
+              alignItems={`left`}
+            >
+              <Stack direction={`row`} alignItems={`center`}>
+                <WordCardFavoriteIcon wordId={wordId} />
+                <WordCardDeleteButton wordId={wordId} />
+                {!word.isArchived && (
+                  <WordCardArchiveButtonPart wordId={wordId} />
+                )}
+                {word.isArchived && (
+                  <WordCardUnarchiveButtonPart wordId={wordId} />
+                )}
+                <WordCardSearchThisWordButtonPart wordId={wordId} />
+                <WordCardShareButtonPart wordId={wordId} />
+              </Stack>
+              <TagButtonChunk word={word} />
+            </Stack>
             <DictLinkButtonChunk wordId={wordId} />
-          </Box>
+          </Stack>
         </CardActions>
       </Card>
     </StyledSuspense>

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -77,6 +77,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           <Box
             sx={{
               display: `flex`,
+              flexWrap: `wrap`,
               width: { xs: `100%`, sm: `auto` },
               alignItems: `center`,
             }}

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { Card, CardActions, CardContent, Typography } from '@mui/material'
+import { Box, Card, CardActions, CardContent, Typography } from '@mui/material'
 import WordCardFavoriteIcon from '../atom_word_card_favorite_icon'
 import WordCardDeleteButton from '../atom_word_card_delete_button'
 import WordCardDeleted from './index.deleted'
@@ -67,15 +67,35 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           </Typography>
           <WordCardExamplePart word={word} />
         </CardContent>
-        <CardActions>
-          <WordCardFavoriteIcon wordId={wordId} />
-          <WordCardDeleteButton wordId={wordId} />
-          {!word.isArchived && <WordCardArchiveButtonPart wordId={wordId} />}
-          {word.isArchived && <WordCardUnarchiveButtonPart wordId={wordId} />}
-          <WordCardSearchThisWordButtonPart wordId={wordId} />
-          <WordCardShareButtonPart wordId={wordId} />
-          <TagButtonChunk word={word} />
-          <DictLinkButtonChunk wordId={wordId} />
+        <CardActions
+          sx={{
+            display: `flex`,
+            flexDirection: { xs: `column`, sm: `row` },
+            alignItems: `flex-start`,
+          }}
+        >
+          <Box
+            sx={{
+              display: `flex`,
+              width: { xs: `100%`, sm: `auto` },
+              alignItems: `center`,
+            }}
+          >
+            <WordCardFavoriteIcon wordId={wordId} />
+            <WordCardDeleteButton wordId={wordId} />
+            {!word.isArchived && <WordCardArchiveButtonPart wordId={wordId} />}
+            {word.isArchived && <WordCardUnarchiveButtonPart wordId={wordId} />}
+            <WordCardSearchThisWordButtonPart wordId={wordId} />
+            <WordCardShareButtonPart wordId={wordId} />
+            <TagButtonChunk word={word} />
+          </Box>
+          <Box
+            sx={{
+              flexDirection: `row`,
+            }}
+          >
+            <DictLinkButtonChunk wordId={wordId} />
+          </Box>
         </CardActions>
       </Card>
     </StyledSuspense>

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -72,11 +72,13 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
             display: `flex`,
             flexDirection: { xs: `column`, sm: `row` },
             alignItems: `flex-start`,
+            flexWrap: 'wrap', 
           }}
         >
           <Box
             sx={{
               display: `flex`,
+              flexDirection: 'row', 
               flexWrap: `wrap`,
               width: { xs: `100%`, sm: `auto` },
               alignItems: `center`,
@@ -92,6 +94,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           </Box>
           <Box
             sx={{
+              display: 'flex',
               flexDirection: `row`,
             }}
           >

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -67,7 +67,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           </Typography>
           <WordCardExamplePart word={word} />
         </CardContent>
-        <CardActions>
+        <CardActions className="custom-card-actions">
           <WordCardFavoriteIcon wordId={wordId} />
           <WordCardDeleteButton wordId={wordId} />
           {!word.isArchived && <WordCardArchiveButtonPart wordId={wordId} />}
@@ -75,7 +75,9 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           <WordCardSearchThisWordButtonPart wordId={wordId} />
           <WordCardShareButtonPart wordId={wordId} />
           <TagButtonChunk word={word} />
-          <DictLinkButtonChunk wordId={wordId} />
+          <div className="dict-link-container">
+            <DictLinkButtonChunk wordId={wordId} />
+          </div>
         </CardActions>
       </Card>
     </StyledSuspense>

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -76,7 +76,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
           <WordCardExamplePart word={word} />
         </CardContent>
         <CardActions>
-          <Stack direction={width > 622 ? `row` : `column`} alignItems={`left`}>
+          <Stack direction={width > 630 ? `row` : `column`} alignItems={`left`}>
             <Stack
               direction={width > 440 ? `row` : `column`}
               alignItems={`left`}

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -108,6 +108,18 @@
   margin-left: 0.5rem;
 }
 
+.custom-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+@media (max-width: 600px) {
+  .dict-link-container {
+    width: 100%; /* If screen width is less than 600px, set width to 100% and display on a new line */
+  }
+}
+
 @media (max-width: 600px) {
   .grid {
     width: 100%;

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -108,18 +108,6 @@
   margin-left: 0.5rem;
 }
 
-.custom-card-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-@media (max-width: 600px) {
-  .dict-link-container {
-    width: 100%; /* If screen width is less than 600px, set width to 100% and display on a new line */
-  }
-}
-
 @media (max-width: 600px) {
   .grid {
     width: 100%;


### PR DESCRIPTION
# Background
https://github.com/ajktown/wordnote/issues/166

## TODOs
- [x] Fix so that it shows every language dictionary icons

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
