### PR TITLE
Introduce dev_wordnote for developers of Wordnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Wordnote](#wordnote)
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
+  - [For Developers](#for-developers)
   - [Public Image](#public-image)
     - [Push image command](#push-image-command)
   - [Depending Libraries](#depending-libraries)
@@ -32,6 +33,10 @@
 Wordnote is the second generation project produced by AJK Town, or AJ Kim. It was renamed after "Wordy".
 
 https://wordnote.ajktown.com
+
+
+## For Developers
+- [Developer guide](https://github.com/ajktown/docs/tree/main/dev_wordnote)
 
 ## Public Image
 


### PR DESCRIPTION
# Background
README.md is introduced for each directory under the dev_wordnote in https://github.com/ajktown/docs/pull/87/files

Make sure that main README.md of Wordnote repository directs the dev doc in ajktown/docs

## TODOs
- [x] README.md of Wordnote repository directs the dev doc in ajktown/docs

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
