### PR TITLE
Favorite Icon forEvery Semester

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You must have permission to push to the repository.
 
 docker build -t ajktown/wordnote:latest .
 docker push ajktown/wordnote:latest
-kubectl apply -f k8s
+kubectl apply -f k8s # TODO: Delete this line please
 
 ```
 

--- a/src/components/atom_tag_chip/index.every-favorite.tsx
+++ b/src/components/atom_tag_chip/index.every-favorite.tsx
@@ -1,0 +1,26 @@
+import StyledIconButtonFavorite from '@/atoms/StyledIconButtonFavorite'
+import StyledChip from '@/atoms/StyledChip'
+import { GlobalMuiTagVariant } from '@/global.interface'
+import { FC, useMemo } from 'react'
+
+const TagChipEveryFavorite: FC = () => {
+  const isFavoriteClicked = true
+
+  const variant: GlobalMuiTagVariant = useMemo(
+    () => (isFavoriteClicked ? `filled` : `outlined`),
+    [isFavoriteClicked],
+  )
+
+  return (
+    <StyledChip
+      label={
+        <StyledIconButtonFavorite isClicked={isFavoriteClicked} size="small" />
+      }
+      style={{
+        variant,
+      }}
+    />
+  )
+}
+
+export default TagChipEveryFavorite

--- a/src/components/atom_tag_chip/index.every-favorite.tsx
+++ b/src/components/atom_tag_chip/index.every-favorite.tsx
@@ -1,7 +1,7 @@
 import StyledIconButtonFavorite from '@/atoms/StyledIconButtonFavorite'
 import StyledChip from '@/atoms/StyledChip'
 import { GlobalMuiTagVariant } from '@/global.interface'
-import { FC, useMemo } from 'react'
+import { FC, useMemo, useState } from 'react'
 import { useWordsByFavorite } from '@/hooks/words/use-words-by-favorite.hook'
 import { useWords } from '@/hooks/words/use-words.hook'
 import { useRecoilCallback, useRecoilValue } from 'recoil'
@@ -9,6 +9,7 @@ import { isEveryFavoriteSelectedState } from '@/recoil/words/semesters.state'
 
 const TagChipEveryFavorite: FC = () => {
   const isEveryFavoriteSelected = useRecoilValue(isEveryFavoriteSelectedState)
+  const [loading, setLoading] = useState(false)
 
   const [, onGetWordsByFavorite] = useWordsByFavorite()
   const [, onGetWords] = useWords()
@@ -22,6 +23,7 @@ const TagChipEveryFavorite: FC = () => {
     ({ snapshot, set }) =>
       async () => {
         try {
+          setLoading(true)
           const isEveryFavoriteSelected = await snapshot.getPromise(
             isEveryFavoriteSelectedState,
           )
@@ -29,7 +31,9 @@ const TagChipEveryFavorite: FC = () => {
           else await onGetWordsByFavorite()
 
           set(isEveryFavoriteSelectedState, !isEveryFavoriteSelected)
-        } catch {}
+        } finally {
+          setLoading(false)
+        }
       },
     [onGetWords, onGetWordsByFavorite],
   )
@@ -42,6 +46,7 @@ const TagChipEveryFavorite: FC = () => {
           size="small"
         />
       }
+      loading={loading}
       onClick={onClick}
       style={{
         variant,

--- a/src/components/atom_tag_chip/index.every-favorite.tsx
+++ b/src/components/atom_tag_chip/index.every-favorite.tsx
@@ -2,20 +2,47 @@ import StyledIconButtonFavorite from '@/atoms/StyledIconButtonFavorite'
 import StyledChip from '@/atoms/StyledChip'
 import { GlobalMuiTagVariant } from '@/global.interface'
 import { FC, useMemo } from 'react'
+import { useWordsByFavorite } from '@/hooks/words/use-words-by-favorite.hook'
+import { useWords } from '@/hooks/words/use-words.hook'
+import { useRecoilCallback, useRecoilValue } from 'recoil'
+import { isEveryFavoriteSelectedState } from '@/recoil/words/semesters.state'
 
 const TagChipEveryFavorite: FC = () => {
-  const isFavoriteClicked = true
+  const isEveryFavoriteSelected = useRecoilValue(isEveryFavoriteSelectedState)
+
+  const [, onGetWordsByFavorite] = useWordsByFavorite()
+  const [, onGetWords] = useWords()
 
   const variant: GlobalMuiTagVariant = useMemo(
-    () => (isFavoriteClicked ? `filled` : `outlined`),
-    [isFavoriteClicked],
+    () => (isEveryFavoriteSelected ? `filled` : `outlined`),
+    [isEveryFavoriteSelected],
+  )
+
+  const onClick = useRecoilCallback(
+    ({ snapshot, set }) =>
+      async () => {
+        try {
+          const isEveryFavoriteSelected = await snapshot.getPromise(
+            isEveryFavoriteSelectedState,
+          )
+          if (isEveryFavoriteSelected) await onGetWords()
+          else await onGetWordsByFavorite()
+
+          set(isEveryFavoriteSelectedState, !isEveryFavoriteSelected)
+        } catch {}
+      },
+    [onGetWords, onGetWordsByFavorite],
   )
 
   return (
     <StyledChip
       label={
-        <StyledIconButtonFavorite isClicked={isFavoriteClicked} size="small" />
+        <StyledIconButtonFavorite
+          isClicked={isEveryFavoriteSelected}
+          size="small"
+        />
       }
+      onClick={onClick}
       style={{
         variant,
       }}

--- a/src/components/atom_tag_chip/index.every-favorite.tsx
+++ b/src/components/atom_tag_chip/index.every-favorite.tsx
@@ -11,8 +11,8 @@ const TagChipEveryFavorite: FC = () => {
   const isEveryFavoriteSelected = useRecoilValue(isEveryFavoriteSelectedState)
   const [loading, setLoading] = useState(false)
 
-  const [, onGetWordsByFavorite] = useWordsByFavorite()
   const [, onGetWords] = useWords()
+  const [, onGetWordsByFavorite] = useWordsByFavorite()
 
   const variant: GlobalMuiTagVariant = useMemo(
     () => (isEveryFavoriteSelected ? `filled` : `outlined`),

--- a/src/components/atom_word_ids_pagination/index.tsx
+++ b/src/components/atom_word_ids_pagination/index.tsx
@@ -1,19 +1,25 @@
+import { useWordsByFavorite } from '@/hooks/words/use-words-by-favorite.hook'
 import { useWords } from '@/hooks/words/use-words.hook'
 import StyledPaginatorMolecule from '@/molecules/StyledPaginator'
+import { isEveryFavoriteSelectedState } from '@/recoil/words/semesters.state'
 import { wordIdsPagination } from '@/recoil/words/words.state'
 import { FC, useCallback } from 'react'
 import { useRecoilValue } from 'recoil'
 
 const WordIdsPagination: FC = () => {
+  const isEveryFavoriteSelected = useRecoilValue(isEveryFavoriteSelectedState)
   const pagination = useRecoilValue(wordIdsPagination)
+
   const [, onGetWords] = useWords()
+  const [, onGetWordsByFavorite] = useWordsByFavorite()
 
   const onChange = useCallback(
     async (newPage: number) => {
       window.scrollTo(0, 0)
-      await onGetWords({ pageIndex: newPage - 1 })
+      if (isEveryFavoriteSelected) await onGetWordsByFavorite(newPage - 1)
+      else await onGetWords({ pageIndex: newPage - 1 })
     },
-    [onGetWords],
+    [isEveryFavoriteSelected, onGetWords, onGetWordsByFavorite],
   )
 
   if (!pagination) return null

--- a/src/components/molecule_tag_button_chunk/index.semesters.tsx
+++ b/src/components/molecule_tag_button_chunk/index.semesters.tsx
@@ -7,6 +7,7 @@ import { FC, useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 import TagChipSemester from '@/components/atom_tag_chip/index.semester'
 import TagChipExpander from '../atom_tag_chip/index.expander'
+import TagChipEveryFavorite from '../atom_tag_chip/index.every-favorite'
 
 const PRIVATE_DEFAULT_EXPAND_ENABLED_COUNT = 3
 
@@ -21,6 +22,7 @@ const TagButtonChunkSemesters: FC = () => {
 
   return (
     <Box>
+      <TagChipEveryFavorite />
       {semesters &&
         semesters
           .slice(0, sliceAt)

--- a/src/components/organism_word_card_chunk/index.no_words_found.tsx
+++ b/src/components/organism_word_card_chunk/index.no_words_found.tsx
@@ -1,5 +1,7 @@
-import { deprecatedSelectedSemesterState } from '@/recoil/words/semesters.state'
-import { isFavoriteClickedSelector } from '@/recoil/words/words.selectors'
+import {
+  isFavoriteClickedSelector,
+  selectedSemesterSelector,
+} from '@/recoil/words/words.selectors'
 import { Typography, Stack } from '@mui/material'
 import { FC, Fragment } from 'react'
 import { useRecoilValue } from 'recoil'
@@ -8,7 +10,7 @@ const PRIVATE_DEFAULT_SELECTED = `Nothing found matching the selected tags`
 const PRIVATE_DEFAULT_NOTHING_FOUND = `It seems like you do not have any words stored in our database`
 
 const WordCardsChunkNoWordsFoundBody: FC = () => {
-  const selectedSemester = useRecoilValue(deprecatedSelectedSemesterState)
+  const selectedSemester = useRecoilValue(selectedSemesterSelector)
   const isFavoriteClicked = useRecoilValue(isFavoriteClickedSelector)
 
   if (isFavoriteClicked || selectedSemester)

--- a/src/hooks/semesters/use-semester-click.hook.ts
+++ b/src/hooks/semesters/use-semester-click.hook.ts
@@ -1,21 +1,25 @@
 import { useRecoilCallback } from 'recoil'
 import { useWords } from '../words/use-words.hook'
+import { isEveryFavoriteSelectedState } from '@/recoil/words/semesters.state'
 
 type UseSemesterClick = [boolean, (clickedSemester: number) => Promise<void>]
 export const useSemesterClick = (): UseSemesterClick => {
   const [loading, onGetWords] = useWords()
 
   const onSemesterClick = useRecoilCallback(
-    () => async (clickedSemester: number) => {
-      await onGetWords({
-        semester: clickedSemester,
-        pageIndex: 0, // must reset page index
-        daysAgo: undefined, // must reset days ago
-        languageCodes: undefined, // must reset language codes
-        isFavorite: undefined, // must reset is favorite
-        tags: undefined, // must reset tags
-      })
-    },
+    ({ reset }) =>
+      async (clickedSemester: number) => {
+        await onGetWords({
+          semester: clickedSemester,
+          pageIndex: 0, // must reset page index
+          daysAgo: undefined, // must reset days ago
+          languageCodes: undefined, // must reset language codes
+          isFavorite: undefined, // must reset is favorite
+          tags: undefined, // must reset tags
+        })
+
+        reset(isEveryFavoriteSelectedState) // reset favorite under any condition if semester is clicked
+      },
     [onGetWords],
   )
 

--- a/src/hooks/words/use-words-by-favorite.hook.ts
+++ b/src/hooks/words/use-words-by-favorite.hook.ts
@@ -2,13 +2,18 @@ import { useRecoilCallback } from 'recoil'
 import { useWords } from './use-words.hook'
 import { useSemesters } from '../semesters/use-semesters.hook'
 import { getWordsApi } from '@/api/words/get-words.api'
-import { wordIdsState, wordsFamily } from '@/recoil/words/words.state'
+import {
+  wordIdsPagination,
+  wordIdsState,
+  wordsFamily,
+} from '@/recoil/words/words.state'
 import { useState } from 'react'
 
 /**
  * Get every word from every semester with isFavorite=true only
+ * if pageIndex is provided, it will get the words from the specific page
  */
-type UseWordsByFavorite = [boolean, () => Promise<void>]
+type UseWordsByFavorite = [boolean, (pageIndex?: number) => Promise<void>]
 export const useWordsByFavorite = (): UseWordsByFavorite => {
   const [loading, setLoading] = useState(false)
   const [, onGetWords] = useWords()
@@ -16,14 +21,15 @@ export const useWordsByFavorite = (): UseWordsByFavorite => {
 
   const onGetWordsByFavorite = useRecoilCallback(
     ({ set }) =>
-      async () => {
+      async (pageIndex?: number) => {
         try {
           setLoading(true)
-          const [data] = await getWordsApi({ isFavorite: true })
+          const [data] = await getWordsApi({ isFavorite: true, pageIndex })
           data.words.forEach((word) => {
             set(wordsFamily(word.id), word)
           })
           set(wordIdsState, data.wordIds)
+          set(wordIdsPagination, data.pagination)
         } finally {
           setLoading(false)
         }

--- a/src/hooks/words/use-words-by-favorite.hook.ts
+++ b/src/hooks/words/use-words-by-favorite.hook.ts
@@ -1,0 +1,35 @@
+import { useRecoilCallback } from 'recoil'
+import { useWords } from './use-words.hook'
+import { useSemesters } from '../semesters/use-semesters.hook'
+import { getWordsApi } from '@/api/words/get-words.api'
+import { wordIdsState, wordsFamily } from '@/recoil/words/words.state'
+import { useState } from 'react'
+
+/**
+ * Get every word from every semester with isFavorite=true only
+ */
+type UseWordsByFavorite = [boolean, () => Promise<void>]
+export const useWordsByFavorite = (): UseWordsByFavorite => {
+  const [loading, setLoading] = useState(false)
+  const [, onGetWords] = useWords()
+  const onGetSemesters = useSemesters()
+
+  const onGetWordsByFavorite = useRecoilCallback(
+    ({ set }) =>
+      async () => {
+        try {
+          setLoading(true)
+          const [data] = await getWordsApi({ isFavorite: true })
+          data.words.forEach((word) => {
+            set(wordsFamily(word.id), word)
+          })
+          set(wordIdsState, data.wordIds)
+        } finally {
+          setLoading(false)
+        }
+      },
+    [onGetSemesters, onGetWords],
+  )
+
+  return [loading, onGetWordsByFavorite]
+}

--- a/src/recoil/words/semesters.state.ts
+++ b/src/recoil/words/semesters.state.ts
@@ -7,10 +7,11 @@ import { Rkp, Rks } from '../index.keys'
 
 /** Private Recoil Key */
 enum Prk {
+  IsEveryFavoriteSelected = `IsEveryFavoriteSelected`,
   Details = `Details`,
   SemesterExpanded = `SemesterExpanded`,
-  DeprecatedSemesterSelected = `DeprecatedSemesterSelected`,
-  LanguageSelected = `LanguageSelected`,
+  DeprecatedSemesterSelected = `DeprecatedSemesterSelected`, // TODO: Delete me
+  LanguageSelected = `LanguageSelected`, // TODO: Delete me
 }
 
 // TODO: I do not understand why semestersState sometimes become undefined ...
@@ -18,6 +19,12 @@ enum Prk {
 export const semestersState = atom<ISemester[] | undefined>({
   key: Rkp.Semesters,
   default: [],
+})
+
+// if a chip "favorite for all" has been selected
+export const isEveryFavoriteSelectedState = atom<boolean>({
+  key: Rkp.Semesters + Prk.IsEveryFavoriteSelected,
+  default: false,
 })
 
 export const semesterDetailsFamily = atomFamily<ISemesterDetailedInfo, number>({
@@ -30,6 +37,7 @@ export const isSemesterExpandedState = atom<boolean>({
   default: false,
 })
 
+// TODO: Delete me
 export const deprecatedSelectedSemesterState = atom<null | number>({
   key: Prk.DeprecatedSemesterSelected,
   default: null,

--- a/src/recoil/words/words.selectors.ts
+++ b/src/recoil/words/words.selectors.ts
@@ -5,6 +5,7 @@ import { Rkp, Rks } from '@/recoil/index.keys'
 import { selector } from 'recoil'
 import { getWordsParamsState } from './words.state'
 import { GlobalLanguageCode } from '@/global.interface'
+import { isEveryFavoriteSelectedState } from './semesters.state'
 
 /** Private Recoil Key */
 enum Prk {
@@ -18,6 +19,9 @@ enum Prk {
 export const selectedSemesterSelector = selector<undefined | number>({
   key: Rkp.Tags + Prk.SelectedSemester + Rks.Selector,
   get: ({ get }) => {
+    // if every favorite chip is clicked, the selected semester is undefined
+    if (get(isEveryFavoriteSelectedState)) return undefined
+
     return get(getWordsParamsState).semester
   },
 })


### PR DESCRIPTION
# Background
You can now select favorite words from every semester you have:
![image](https://github.com/ajktown/wordnote/assets/53258958/ad11ec8b-1da9-46ab-a776-806333414549)


## TODOs
- [x] Implement a chip that selects favorite words from every semester users have
- [x] Pagination works too with it
- [x] Once clicked, it should do the loading too

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
