### PR TITLE
Implement `command + enter` for apply modification

### DIFF
--- a/src/components/atom_word_card_confirm_modify_button/index.tsx
+++ b/src/components/atom_word_card_confirm_modify_button/index.tsx
@@ -1,5 +1,5 @@
 import StyledTextButtonAtom from '@/atoms/StyledTextButton'
-import { FC } from 'react'
+import { FC, useEffect } from 'react'
 import { usePutWordCache } from '@/hooks/words/use-put-word-cache.hook'
 import { usePutWordCacheByKey } from '@/hooks/words/use-put-word-cache-by-key.hook'
 interface Props {
@@ -20,6 +20,18 @@ const WordCardConfirmModifyButton: FC<Props> = ({ wordId }) => {
     wordId,
     `exampleLink`,
   )
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === `Enter`) {
+        handleApplyCache()
+      }
+    }
+    document.addEventListener(`keydown`, handleKeyDown)
+    return () => {
+      document.removeEventListener(`keydown`, handleKeyDown)
+    }
+  })
 
   if (
     !isTermModified &&

--- a/src/components/atom_word_card_confirm_modify_button/index.tsx
+++ b/src/components/atom_word_card_confirm_modify_button/index.tsx
@@ -2,6 +2,7 @@ import StyledTextButtonAtom from '@/atoms/StyledTextButton'
 import { FC, useEffect } from 'react'
 import { usePutWordCache } from '@/hooks/words/use-put-word-cache.hook'
 import { usePutWordCacheByKey } from '@/hooks/words/use-put-word-cache-by-key.hook'
+import { useKeyPress } from '@/hooks/use-key-press.hook'
 interface Props {
   wordId: string
 }
@@ -32,6 +33,9 @@ const WordCardConfirmModifyButton: FC<Props> = ({ wordId }) => {
       document.removeEventListener(`keydown`, handleKeyDown)
     }
   })
+
+  useKeyPress(handleApplyCache, `Meta`, `Enter`)
+  useKeyPress(handleApplyCache, `Control`, `Enter`)
 
   if (
     !isTermModified &&

--- a/src/components/atom_word_card_confirm_modify_button/index.tsx
+++ b/src/components/atom_word_card_confirm_modify_button/index.tsx
@@ -23,8 +23,8 @@ const WordCardConfirmModifyButton: FC<Props> = ({ wordId }) => {
   )
 
 
-  useKeyPress(handleApplyCache, `Meta`, `Enter`)
-  useKeyPress(handleApplyCache, `Control`, `Enter`)
+  useKeyPress(handleApplyCache, `Meta`, `Enter`) // for mac
+  useKeyPress(handleApplyCache, `Control`, `Enter`) // for windows
 
   if (
     !isTermModified &&

--- a/src/components/atom_word_card_confirm_modify_button/index.tsx
+++ b/src/components/atom_word_card_confirm_modify_button/index.tsx
@@ -1,5 +1,5 @@
 import StyledTextButtonAtom from '@/atoms/StyledTextButton'
-import { FC, useEffect } from 'react'
+import { FC } from 'react'
 import { usePutWordCache } from '@/hooks/words/use-put-word-cache.hook'
 import { usePutWordCacheByKey } from '@/hooks/words/use-put-word-cache-by-key.hook'
 import { useKeyPress } from '@/hooks/use-key-press.hook'

--- a/src/components/atom_word_card_confirm_modify_button/index.tsx
+++ b/src/components/atom_word_card_confirm_modify_button/index.tsx
@@ -22,17 +22,6 @@ const WordCardConfirmModifyButton: FC<Props> = ({ wordId }) => {
     `exampleLink`,
   )
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key === `Enter`) {
-        handleApplyCache()
-      }
-    }
-    document.addEventListener(`keydown`, handleKeyDown)
-    return () => {
-      document.removeEventListener(`keydown`, handleKeyDown)
-    }
-  })
 
   useKeyPress(handleApplyCache, `Meta`, `Enter`)
   useKeyPress(handleApplyCache, `Control`, `Enter`)

--- a/src/components/molecule_new_word_box/index.tsx
+++ b/src/components/molecule_new_word_box/index.tsx
@@ -38,8 +38,8 @@ const NewWordBox: FC = () => {
     else setWritingMode(true)
   }, [isWritingMode, setWritingMode, onDynamicFocus])
 
-  useKeyPress(`Enter`, onHitEnter)
-  useKeyPress(`Escape`, onClickPostWordWritingModeClose)
+  useKeyPress(onHitEnter, `Enter`)
+  useKeyPress(onClickPostWordWritingModeClose, `Escape`)
   const ref = useOutsideClicked(onClickPostWordWritingModeClose)
 
   if (searchInput || isShowingArchived) return null

--- a/src/global.interface.ts
+++ b/src/global.interface.ts
@@ -37,7 +37,7 @@ export type GlobalKeyboardEventKey =
   | 'ArrowLeft'
   | 'ArrowUp'
   | 'ArrowDown'
-  | 'Meta'
+  | 'Meta' // ⌘ in Apple Ecosystem
   | 'Control'
 
 export type GlobalMuiSize = 'small' | 'medium' | 'large'

--- a/src/global.interface.ts
+++ b/src/global.interface.ts
@@ -37,6 +37,8 @@ export type GlobalKeyboardEventKey =
   | 'ArrowLeft'
   | 'ArrowUp'
   | 'ArrowDown'
+  | 'Meta'
+  | 'Control'
 
 export type GlobalMuiSize = 'small' | 'medium' | 'large'
 

--- a/src/hooks/use-key-press.hook.ts
+++ b/src/hooks/use-key-press.hook.ts
@@ -24,5 +24,5 @@ export const useKeyPress = (
     return () => {
       document.removeEventListener(`keydown`, onKeyDown)
     }
-  }, [onKeyPress, ...keyNames])
+  }, [onKeyPress, keyNames])
 }

--- a/src/hooks/use-key-press.hook.ts
+++ b/src/hooks/use-key-press.hook.ts
@@ -3,12 +3,16 @@ import { useEffect } from 'react'
 
 // TODO: This will eventually have multiple keys pushed, or it will have a separate file for such.
 export const useKeyPress = (
-  keyName: GlobalKeyboardEventKey,
   onKeyPress: () => any,
+  ...keyNames: GlobalKeyboardEventKey[]
 ) => {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.isComposing || event.key !== keyName) return
+      if (
+        event.isComposing ||
+        !keyNames.includes(event.key as GlobalKeyboardEventKey)
+      )
+        return
 
       event.preventDefault()
       onKeyPress()
@@ -20,5 +24,5 @@ export const useKeyPress = (
     return () => {
       document.removeEventListener(`keydown`, onKeyDown)
     }
-  }, [keyName, onKeyPress])
+  }, [onKeyPress, ...keyNames])
 }


### PR DESCRIPTION
# Background
https://github.com/ajktown/wordnote/issues/202

## TODOs
- [x] The dialog reads the input `command + enter` and run `modify`

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
