### PR TITLE
Implement 'command + enter' for apply new tag

### DIFF
--- a/src/components/atom_word_card_add_tag_button/index.tsx
+++ b/src/components/atom_word_card_add_tag_button/index.tsx
@@ -23,10 +23,11 @@ const WordCardAddTagButton: FC<Props> = ({ wordId }) => {
     setAddingMode(false)
   }, [])
   const [loading, onPutWordTagAdded] = usePutWordTagAdded(wordId, onResetInput)
-  const onClick = useCallback(
-    () => onPutWordTagAdded(input),
-    [input, onPutWordTagAdded],
-  )
+  const onClick = useCallback(() => {
+    if (!loading && input.length > 0) {
+      onPutWordTagAdded(input)
+    }
+  }, [input, onPutWordTagAdded, loading])
   useKeyPress(onClick, `Meta`, `Enter`) // for mac
   useKeyPress(onClick, `Control`, `Enter`) // for windows
 

--- a/src/components/atom_word_card_add_tag_button/index.tsx
+++ b/src/components/atom_word_card_add_tag_button/index.tsx
@@ -7,6 +7,7 @@ import StyledDialog from '@/organisms/StyledDialog'
 import { DialogContent, DialogTitle } from '@mui/material'
 import { useDynamicFocus } from '@/hooks/use-dynamic-focus.hook'
 import { usePutWordTagAdded } from '@/hooks/words/use-put-word-tag-added.hook'
+import { useKeyPress } from '@/hooks/use-key-press.hook'
 
 interface Props {
   wordId: string
@@ -26,6 +27,8 @@ const WordCardAddTagButton: FC<Props> = ({ wordId }) => {
     () => onPutWordTagAdded(input),
     [input, onPutWordTagAdded],
   )
+  useKeyPress(onClick, `Meta`, `Enter`) // for mac
+  useKeyPress(onClick, `Control`, `Enter`) // for windows
 
   return (
     <Fragment>

--- a/src/components/atom_word_card_confirm_modify_button/index.tsx
+++ b/src/components/atom_word_card_confirm_modify_button/index.tsx
@@ -22,7 +22,6 @@ const WordCardConfirmModifyButton: FC<Props> = ({ wordId }) => {
     `exampleLink`,
   )
 
-
   useKeyPress(handleApplyCache, `Meta`, `Enter`) // for mac
   useKeyPress(handleApplyCache, `Control`, `Enter`) // for windows
 

--- a/src/components/molecule_new_word_box/index.tsx
+++ b/src/components/molecule_new_word_box/index.tsx
@@ -10,12 +10,14 @@ import { searchInputState } from '@/recoil/words/searchInput.state'
 import WordCardSkeleton from '../molecule_word_card/index.skeleton'
 import { useDynamicFocus } from '@/hooks/use-dynamic-focus.hook'
 import { isShowingArchivedState } from '@/recoil/preferences/preference.state'
+import { selectedWordIdForDialogState } from '@/recoil/words/words.state'
 
 const PRIVATE_FINAL_ADD_NEW_WORD_MESSAGE = `Add your new word...`
 
 const NewWordBox: FC = () => {
   const searchInput = useRecoilValue(searchInputState)
   const isShowingArchived = useRecoilValue(isShowingArchivedState)
+  const selectedWordId = useRecoilValue(selectedWordIdForDialogState)
 
   // TODO: This is possibly too long. I think it could be better,
   // TODO: But then for the current code status sake, it looks good.
@@ -34,9 +36,12 @@ const NewWordBox: FC = () => {
     onClickPostWordWritingModeOpen,
   )
   const onHitEnter = useCallback(() => {
+    // if dialog is open for edit, it should exit by return
+    if (selectedWordId) return
+
     if (isWritingMode) onDynamicFocus()
     else setWritingMode(true)
-  }, [isWritingMode, setWritingMode, onDynamicFocus])
+  }, [selectedWordId, isWritingMode, setWritingMode, onDynamicFocus])
 
   useKeyPress(onHitEnter, `Enter`)
   useKeyPress(onClickPostWordWritingModeClose, `Escape`)


### PR DESCRIPTION
# Background
Implemented `command + enter` for apply modification in the word card dialog. (Handled in https://github.com/ajktown/wordnote/pull/210)
I think it would be useful to implement `command + enter` for apply when creating a new tag.
![image](https://github.com/ajktown/wordnote/assets/128212558/e8f097c7-e7b8-4547-895d-d7a8e885c9dd)

## TODOs
- [x]  The creating new tag dialog reads the input command + enter and run modify

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
