### PR TITLE
Sub defintion editable

### DIFF
--- a/src/api/words/interfaces/index.ts
+++ b/src/api/words/interfaces/index.ts
@@ -8,6 +8,7 @@ export interface ISharedWord {
   term: string
   pronunciation: string
   definition: string
+  subDefinition: string
   example: string
   exampleLink: string
   tags: string[]

--- a/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
+++ b/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
@@ -28,6 +28,7 @@ const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
         term: sharedWord.word.term,
         pronunciation: sharedWord.word.pronunciation,
         definition: sharedWord.word.definition,
+        subDefinition: sharedWord.word.subDefinition,
         example: sharedWord.word?.example,
         exampleLink: ``,
         tags: [],

--- a/src/components/atom_word_card_confirm_modify_button/index.tsx
+++ b/src/components/atom_word_card_confirm_modify_button/index.tsx
@@ -16,6 +16,10 @@ const WordCardConfirmModifyButton: FC<Props> = ({ wordId }) => {
     `pronunciation`,
   )
   const [, , isDefinitionModified] = usePutWordCacheByKey(wordId, `definition`)
+  const [, , isSubDefinitionModified] = usePutWordCacheByKey(
+    wordId,
+    `subDefinition`,
+  )
   const [, , isExampleModified] = usePutWordCacheByKey(wordId, `example`)
   const [, , isExampleLinkModified] = usePutWordCacheByKey(
     wordId,
@@ -29,6 +33,7 @@ const WordCardConfirmModifyButton: FC<Props> = ({ wordId }) => {
     !isTermModified &&
     !isPronunciationModified &&
     !isDefinitionModified &&
+    !isSubDefinitionModified &&
     !isExampleModified &&
     !isExampleLinkModified
   )

--- a/src/components/atom_word_card_parts/index.definition.tsx
+++ b/src/components/atom_word_card_parts/index.definition.tsx
@@ -1,0 +1,21 @@
+import { ISharedWord } from '@/api/words/interfaces'
+import { Typography } from '@mui/material'
+import { FC } from 'react'
+
+interface Props {
+  word: ISharedWord
+  hideSubDefinition?: boolean // true: does not display sub definition
+}
+const WordCardDefinitionPart: FC<Props> = ({ word, hideSubDefinition }) => {
+  return (
+    <Typography variant="body2">
+      {word.definition}
+      {!hideSubDefinition && word.subDefinition
+        ? ` (${word.subDefinition})`
+        : ``}
+      <br />
+    </Typography>
+  )
+}
+
+export default WordCardDefinitionPart

--- a/src/components/atom_word_card_parts/index.definition.tsx
+++ b/src/components/atom_word_card_parts/index.definition.tsx
@@ -1,20 +1,22 @@
 import { ISharedWord } from '@/api/words/interfaces'
-import { Typography } from '@mui/material'
+import { Stack, Typography } from '@mui/material'
 import { FC } from 'react'
 
+// TODO: I think we can design later phase (for now it works)
 interface Props {
   word: ISharedWord
   hideSubDefinition?: boolean // true: does not display sub definition
 }
 const WordCardDefinitionPart: FC<Props> = ({ word, hideSubDefinition }) => {
   return (
-    <Typography variant="body2">
-      {word.definition}
-      {!hideSubDefinition && word.subDefinition
-        ? ` (${word.subDefinition})`
-        : ``}
-      <br />
-    </Typography>
+    <Stack spacing={0}>
+      <Typography variant="body2">{word.definition}</Typography>
+      {!hideSubDefinition && word.subDefinition && (
+        <Typography variant="body2" color="text.secondary" fontStyle={'italic'}>
+          {word.subDefinition}
+        </Typography>
+      )}
+    </Stack>
   )
 }
 

--- a/src/components/atom_word_card_parts/index.term-and-pronunciation.tsx
+++ b/src/components/atom_word_card_parts/index.term-and-pronunciation.tsx
@@ -5,7 +5,7 @@ import { FC } from 'react'
 interface Props {
   word: ISharedWord
 }
-const WordCardTermAndPronunciation: FC<Props> = ({ word }) => {
+const WordCardTermAndPronunciationPart: FC<Props> = ({ word }) => {
   return (
     <Stack alignItems="center" direction="row" spacing={0.5} mb={0.5}>
       <Typography variant="h5" component="div">
@@ -20,4 +20,4 @@ const WordCardTermAndPronunciation: FC<Props> = ({ word }) => {
   )
 }
 
-export default WordCardTermAndPronunciation
+export default WordCardTermAndPronunciationPart

--- a/src/components/molecule_word_card/index.editing_mode.tsx
+++ b/src/components/molecule_word_card/index.editing_mode.tsx
@@ -25,6 +25,10 @@ const WordCardEditingMode: FC<Props> = ({ wordId }) => {
               wordId={wordId}
             />
             <WordCardEditingTextField wordKey={`definition`} wordId={wordId} />
+            <WordCardEditingTextField
+              wordKey={`subDefinition`}
+              wordId={wordId}
+            />
             <WordCardEditingTextField wordKey={`example`} wordId={wordId} />
             <WordCardEditingTextField wordKey={`exampleLink`} wordId={wordId} />
             <TagButtonDeletableChunk wordId={wordId} />

--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -20,7 +20,8 @@ import WordCardShareButtonPart from '../atom_word_card_parts/index.share-button'
 import DictLinkButtonChunk from '../molecule_dict_link_button_chunk'
 import WordCardSearchThisWordButtonPart from '../atom_word_card_parts/index.search-this-word'
 import { useWindowSize } from 'react-use'
-import WordCardTermAndPronunciation from '../atom_word_card_parts/index.term-and-pronunciation'
+import WordCardTermAndPronunciationPart from '../atom_word_card_parts/index.term-and-pronunciation'
+import WordCardDefinitionPart from '../atom_word_card_parts/index.definition'
 interface Props {
   word: WordData
 }
@@ -42,16 +43,13 @@ const WordCardReviewMode: FC<Props> = ({ word }) => {
     <StyledSuspense>
       <Card style={{ width: `100%`, borderRadius: 9 }}>
         <CardContent onClick={onClickWordCard}>
-          {isPeekMode && <WordCardTermAndPronunciation word={word} />}
+          {isPeekMode && <WordCardTermAndPronunciationPart word={word} />}
           {!isPeekMode && (
             <Typography variant="h5" component="div">
               {`???`}
             </Typography>
           )}
-          <Typography variant="body2">
-            {word.definition}
-            <br />
-          </Typography>
+          <WordCardDefinitionPart word={word} hideSubDefinition={!isPeekMode} />
           <WordCardExamplePart word={word} reviewMode={!isPeekMode} />
         </CardContent>
         <CardActions>

--- a/src/components/molecule_word_card/index.search_dialog.tsx
+++ b/src/components/molecule_word_card/index.search_dialog.tsx
@@ -21,7 +21,8 @@ import { useSearchedWordsByWordId } from '@/hooks/words/use-searched-words-by-wo
 import TagButtonChunk from '../molecule_tag_button_chunk'
 import StyledTextButtonAtom from '@/atoms/StyledTextButton'
 import { wordsFamily } from '@/recoil/words/words.state'
-import WordCardTermAndPronunciation from '../atom_word_card_parts/index.term-and-pronunciation'
+import WordCardTermAndPronunciationPart from '../atom_word_card_parts/index.term-and-pronunciation'
+import WordCardDefinitionPart from '../atom_word_card_parts/index.definition'
 
 const WordCardSearchDialog: FC = () => {
   const searchingWordId = useRecoilValue(searchByWordIdState)
@@ -92,11 +93,8 @@ const WordCardSearchDialog: FC = () => {
             <StyledSuspense key={word.id}>
               <Card style={{ width: `100%`, borderRadius: 9 }}>
                 <CardContent>
-                  <WordCardTermAndPronunciation word={word} />
-                  <Typography variant="body2">
-                    {word.definition}
-                    <br />
-                  </Typography>
+                  <WordCardTermAndPronunciationPart word={word} />
+                  <WordCardDefinitionPart word={word} />
                   <WordCardExamplePart word={word} />
                 </CardContent>
                 <CardActions>

--- a/src/components/molecule_word_card/index.share-review.tsx
+++ b/src/components/molecule_word_card/index.share-review.tsx
@@ -1,11 +1,5 @@
 import { FC } from 'react'
-import {
-  Card,
-  CardActions,
-  CardContent,
-  Stack,
-  Typography,
-} from '@mui/material'
+import { Card, CardActions, CardContent, Typography } from '@mui/material'
 import { useRecoilValue } from 'recoil'
 import WordCardUnknown from './index.unknown'
 import StyledSuspense from '@/organisms/StyledSuspense'
@@ -13,7 +7,8 @@ import WordCardExamplePart from '../atom_word_card_parts/index.example'
 import WordCardSkeleton from './index.skeleton'
 import { wordsFamily } from '@/recoil/words/words.state'
 import TagButtonChunk from '../molecule_tag_button_chunk'
-import WordCardTermAndPronunciation from '../atom_word_card_parts/index.term-and-pronunciation'
+import WordCardTermAndPronunciationPart from '../atom_word_card_parts/index.term-and-pronunciation'
+import WordCardDefinitionPart from '../atom_word_card_parts/index.definition'
 
 interface Props {
   wordId: string
@@ -29,11 +24,8 @@ const WordCardShareReview: FC<Props> = ({ wordId }) => {
     <StyledSuspense>
       <Card style={{ width: `100%`, borderRadius: 9 }}>
         <CardContent>
-          <WordCardTermAndPronunciation word={shareReviewWord} />
-          <Typography variant="body2">
-            {shareReviewWord.definition}
-            <br />
-          </Typography>
+          <WordCardTermAndPronunciationPart word={shareReviewWord} />
+          <WordCardDefinitionPart word={shareReviewWord} />
           <WordCardExamplePart word={shareReviewWord} />
         </CardContent>
         <CardActions>

--- a/src/components/molecule_word_card/index.shared.tsx
+++ b/src/components/molecule_word_card/index.shared.tsx
@@ -19,7 +19,8 @@ import { PageQueryConst } from '@/constants/page-queries.constant'
 import StyledCountdownTimer from '@/atoms/StyledCountdownTimer'
 import TagButtonLanguage from '../atom_tag_chip/index.language'
 import TagChipCustomized from '../atom_tag_chip/index.customized'
-import WordCardTermAndPronunciation from '../atom_word_card_parts/index.term-and-pronunciation'
+import WordCardTermAndPronunciationPart from '../atom_word_card_parts/index.term-and-pronunciation'
+import WordCardDefinitionPart from '../atom_word_card_parts/index.definition'
 
 interface Props {
   wordId: string
@@ -51,11 +52,8 @@ const WordCardShared: FC<Props> = ({ wordId }) => {
     <StyledSuspense>
       <Card style={{ width: `100%`, borderRadius: 9 }}>
         <CardContent>
-          <WordCardTermAndPronunciation word={sharedWord.word} />
-          <Typography variant="body2">
-            {sharedWord.word.definition}
-            <br />
-          </Typography>
+          <WordCardTermAndPronunciationPart word={sharedWord.word} />
+          <WordCardDefinitionPart word={sharedWord.word} />
           <WordCardExamplePart word={sharedWord.word} />
         </CardContent>
         <CardActions>

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -31,7 +31,8 @@ import WordCardReviewMode from './index.review_mode'
 import WordCardShareButtonPart from '../atom_word_card_parts/index.share-button'
 import WordCardSearchThisWordButtonPart from '../atom_word_card_parts/index.search-this-word'
 import { useWindowSize } from 'react-use'
-import WordCardTermAndPronunciation from '../atom_word_card_parts/index.term-and-pronunciation'
+import WordCardTermAndPronunciationPart from '../atom_word_card_parts/index.term-and-pronunciation'
+import WordCardDefinitionPart from '../atom_word_card_parts/index.definition'
 
 interface Props {
   wordId: string
@@ -64,11 +65,8 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
     <StyledSuspense>
       <Card style={{ width: `100%`, borderRadius: 9 }}>
         <CardContent onClick={onClickWordCard}>
-          <WordCardTermAndPronunciation word={word} />
-          <Typography variant="body2">
-            {word.definition}
-            <br />
-          </Typography>
+          <WordCardTermAndPronunciationPart word={word} />
+          <WordCardDefinitionPart word={word} />
           <WordCardExamplePart word={word} />
         </CardContent>
         <CardActions>

--- a/src/hooks/words/use-put-word-cache.hook.ts
+++ b/src/hooks/words/use-put-word-cache.hook.ts
@@ -40,6 +40,7 @@ export const usePutWordCache = (wordId: string | null): UsePutWordCache => {
         ...(await getObjectWithKey(`isFavorite`)),
         ...(await getObjectWithKey(`pronunciation`)),
         ...(await getObjectWithKey(`definition`)),
+        ...(await getObjectWithKey(`subDefinition`)),
         ...(await getObjectWithKey(`example`)),
         ...(await getObjectWithKey(`exampleLink`)),
       }
@@ -67,6 +68,7 @@ export const usePutWordCache = (wordId: string | null): UsePutWordCache => {
     await handleResetByKey(`isFavorite`)
     await handleResetByKey(`pronunciation`)
     await handleResetByKey(`definition`)
+    await handleResetByKey(`subDefinition`)
     await handleResetByKey(`example`)
     await handleResetByKey(`exampleLink`)
   }, [handleResetByKey])

--- a/src/lambdas/parse-input-into-word.lambda.ts
+++ b/src/lambdas/parse-input-into-word.lambda.ts
@@ -48,6 +48,7 @@ export const parseInputIntoWordLambda = (given: string): PostWordReqDto => {
     pronunciation: pronunciation.trim(),
     definition: definition.trim(),
     example: example.trim(),
+    subDefinition: ``,
     exampleLink: ``,
     isFavorite: false,
     tags,


### PR DESCRIPTION
# Background
You can edit sub definition on FE too after the API implementation: https://github.com/ajktown/api/pull/122
If you go ReviewMode, your sub definition won't be visible, and you can utilize this not to show hints during the review.

Editing:
<img width="943" alt="image" src="https://github.com/ajktown/wordnote/assets/53258958/f3c8e5cd-9f95-4c7c-a7c0-40d2e20c53c4">

Visual:
<img width="641" alt="image" src="https://github.com/ajktown/wordnote/assets/53258958/1bff8e96-9676-4540-960b-6137f3e6903e">

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
