### PR TITLE
Use patch instead

### DIFF
--- a/src/api/preferences/patch-preference.api.ts
+++ b/src/api/preferences/patch-preference.api.ts
@@ -2,10 +2,10 @@ import axios from 'axios'
 import { CustomizedAxiosResponse } from '../index.interface'
 import { IPreference, PreferenceModifiable } from './index.interface'
 
-export const putPreferenceApi = async (
+export const patchPreferenceApi = async (
   modifying: Partial<PreferenceModifiable>,
 ): Promise<CustomizedAxiosResponse<IPreference>> => {
   const url = `/v1/preference`
-  const res = await axios.put(url, modifying)
+  const res = await axios.patch(url, modifying)
   return [res.data, res]
 }

--- a/src/api/words/patch-word-by-id.api.ts
+++ b/src/api/words/patch-word-by-id.api.ts
@@ -2,11 +2,11 @@ import axios from 'axios'
 import { WordData, WordDataModifiable } from './interfaces'
 import { CustomizedAxiosResponse } from '../index.interface'
 
-export const putWordByIdApi = async (
+export const patchWordByIdApi = async (
   wordId: string,
   modifying: Partial<WordDataModifiable>,
 ): Promise<CustomizedAxiosResponse<WordData>> => {
   const url = `/v1/words/${wordId}`
-  const res = await axios.put(url, modifying)
+  const res = await axios.patch(url, modifying)
   return [res.data, res]
 }

--- a/src/components/atom_preference_language_checkbox/index.tsx
+++ b/src/components/atom_preference_language_checkbox/index.tsx
@@ -1,6 +1,6 @@
 import { getLanguageFullName } from '@/global.constants'
 import { GlobalLanguageCode } from '@/global.interface'
-import { usePutPreferenceNativeLanguage } from '@/hooks/preference/use-put-preference-native-language.hook'
+import { usePutPreferenceNativeLanguage } from '@/hooks/preference/use-patch-preference-native-language.hook'
 import { preferenceState } from '@/recoil/preferences/preference.state'
 import { Checkbox, FormControlLabel } from '@mui/material'
 import { FC } from 'react'

--- a/src/components/molecule_gpt_key_registerer/index.tsx
+++ b/src/components/molecule_gpt_key_registerer/index.tsx
@@ -5,12 +5,12 @@ import { FC, Fragment, useCallback, useState } from 'react'
 import { useRecoilValue } from 'recoil'
 import CheckIcon from '@mui/icons-material/Check'
 import ClearIcon from '@mui/icons-material/Clear'
-import { usePutPreference } from '@/hooks/preference/use-put-preference.hook'
+import { usePatchPreference } from '@/hooks/preference/use-patch-preference.hook'
 
 const GptKeyRegisterer: FC = () => {
   const gptApiKey = useRecoilValue(gptApiKeySelector)
   const [input, setInput] = useState<string>(gptApiKey)
-  const onPutPreference = usePutPreference()
+  const onPutPreference = usePatchPreference()
   const [loading, setLoading] = useState(false)
 
   const onClickApply = useCallback(async () => {

--- a/src/hooks/preference/use-patch-preference-native-language.hook.ts
+++ b/src/hooks/preference/use-patch-preference-native-language.hook.ts
@@ -1,12 +1,12 @@
 import { useRecoilCallback } from 'recoil'
 import { preferenceState } from '@/recoil/preferences/preference.state'
 import { GlobalLanguageCode } from '@/global.interface'
-import { usePutPreference } from './use-put-preference.hook'
+import { usePatchPreference } from './use-patch-preference.hook'
 
 export const usePutPreferenceNativeLanguage = (
   languageCode: GlobalLanguageCode,
 ) => {
-  const onPutPreference = usePutPreference()
+  const onPutPreference = usePatchPreference()
   const onPutPreferenceNativeLanguage = useRecoilCallback(
     ({ snapshot }) =>
       async (_, checked: boolean) => {

--- a/src/hooks/preference/use-patch-preference.hook.ts
+++ b/src/hooks/preference/use-patch-preference.hook.ts
@@ -1,19 +1,19 @@
 import { useRecoilCallback } from 'recoil'
 import { preferenceState } from '@/recoil/preferences/preference.state'
-import { putPreferenceApi } from '@/api/preferences/put-preference.api'
+import { patchPreferenceApi } from '@/api/preferences/patch-preference.api'
 import { PreferenceModifiable } from '@/api/preferences/index.interface'
 
-export const usePutPreference = () => {
-  const onPutPreference = useRecoilCallback(
+export const usePatchPreference = () => {
+  const onPatchPreference = useRecoilCallback(
     ({ set }) =>
       async (modifying: Partial<PreferenceModifiable>) => {
         try {
-          const [data] = await putPreferenceApi(modifying)
+          const [data] = await patchPreferenceApi(modifying)
           set(preferenceState, data)
         } catch {}
       },
     [],
   )
 
-  return onPutPreference
+  return onPatchPreference
 }

--- a/src/hooks/words/use-put-word-cache.hook.ts
+++ b/src/hooks/words/use-put-word-cache.hook.ts
@@ -1,4 +1,4 @@
-import { putWordByIdApi } from '@/api/words/put-word-by-id.api'
+import { patchWordByIdApi } from '@/api/words/patch-word-by-id.api'
 import {
   WordDataModifiable,
   WordDataModifiableKey,
@@ -84,7 +84,7 @@ export const usePutWordCache = (wordId: string | null): UsePutWordCache => {
         const modified = await getObject()
         if (isEmptyObjectHandler(modified)) return
 
-        const [modifiedWord] = await putWordByIdApi(wordId, modified)
+        const [modifiedWord] = await patchWordByIdApi(wordId, modified)
         set(wordsFamily(wordId), modifiedWord)
 
         // TODO: This is causing first deletion and then creation for UI

--- a/src/hooks/words/use-put-word.hook.ts
+++ b/src/hooks/words/use-put-word.hook.ts
@@ -1,4 +1,4 @@
-import { putWordByIdApi } from '@/api/words/put-word-by-id.api'
+import { patchWordByIdApi } from '@/api/words/patch-word-by-id.api'
 import { WordDataModifiable } from '@/api/words/interfaces'
 import { wordsFamily } from '@/recoil/words/words.state'
 import { useRecoilCallback } from 'recoil'
@@ -20,7 +20,7 @@ export const usePutWord = (wordId: string): UsePutWord => {
           const wordData = await snapshot.getPromise(wordsFamily(wordId))
           if (wordData == null) return
 
-          const [modifiedWord] = await putWordByIdApi(wordId, modified)
+          const [modifiedWord] = await patchWordByIdApi(wordId, modified)
           set(wordsFamily(wordId), modifiedWord)
         } finally {
           setLoading(false)


### PR DESCRIPTION
# Background
Use patch instead, as the `PUT` apis will be deprecated in the following issue: https://github.com/ajktown/api/issues/131

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
