### PR TITLE
GitHub Action for Automatic Docker Registry Push

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,41 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ajktown
+        password: ${{ secrets.AJKTOWN_ORG_ACTION }}
+
+    - name: Build the Docker image for PR
+      if: github.event_name == 'pull_request'
+      run: docker build . --file Dockerfile --tag ajktown/consistency:pr-${{ github.event.pull_request.number }}
+
+    - name: Push the Docker image for PR
+      if: github.event_name == 'pull_request'
+      run: docker push ajktown/consistency:pr${{ github.event.pull_request.number }}
+
+    - name: Build the Docker image as latest
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: docker build . --file Dockerfile --tag ajktown/consistency:latest
+
+    - name: Push the Docker image as latest
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: docker push ajktown/consistency:latest

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -26,16 +26,16 @@ jobs:
 
     - name: Build the Docker image for PR
       if: github.event_name == 'pull_request'
-      run: docker build . --file Dockerfile --tag ajktown/consistency:pr-${{ github.event.pull_request.number }}
+      run: docker build . --file Dockerfile --tag ajktown/wordnote:pr${{ github.event.pull_request.number }}
 
     - name: Push the Docker image for PR
       if: github.event_name == 'pull_request'
-      run: docker push ajktown/consistency:pr${{ github.event.pull_request.number }}
+      run: docker push ajktown/wordnote:pr${{ github.event.pull_request.number }}
 
     - name: Build the Docker image as latest
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: docker build . --file Dockerfile --tag ajktown/consistency:latest
+      run: docker build . --file Dockerfile --tag ajktown/wordnote:latest
 
     - name: Push the Docker image as latest
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: docker push ajktown/consistency:latest
+      run: docker push ajktown/wordnote:latest

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   - [Overview](#overview)
   - [For Developers](#for-developers)
   - [Public Image](#public-image)
-    - [Push image command](#push-image-command)
+    - [Push image command locally](#push-image-command-locally)
   - [Depending Libraries](#depending-libraries)
     - [Luxon](#luxon)
   - [Package json scripts](#package-json-scripts)
@@ -43,8 +43,8 @@ https://wordnote.ajktown.com
 https://hub.docker.com/r/ajktown/wordnote/tags
 
 
-### Push image command
-You must have permission to push to the repository.
+### Push image command locally
+By default, the GitHub Action will build and push the image to the Docker Hub. If you want to push the image locally, you can use the following commands:
 ```sh
 
 docker build -t ajktown/wordnote:latest .


### PR DESCRIPTION
# Background
Locally pushing image every time you make a release is tedious.

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
