### PR TITLE
Disable Docker Build for latest

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -32,10 +32,10 @@ jobs:
       if: github.event_name == 'pull_request'
       run: docker push ajktown/wordnote:pr${{ github.event.pull_request.number }}
 
-    - name: Build the Docker image as latest
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: docker build . --file Dockerfile --tag ajktown/wordnote:latest
+    # - name: Build the Docker image as latest
+    #   if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    #   run: docker build . --file Dockerfile --tag ajktown/wordnote:latest
 
-    - name: Push the Docker image as latest
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: docker push ajktown/wordnote:latest
+    # - name: Push the Docker image as latest
+    #   if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    #   run: docker push ajktown/wordnote:latest


### PR DESCRIPTION
# Background
The current pipeline builds an image on x86, and therefore should disable it temporarily.

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled


