### PR TITLE
Feat: Wordcard in Review Mode shows country flag to review easier

### DIFF
--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -23,6 +23,7 @@ import { useWindowSize } from 'react-use'
 import WordCardTermAndPronunciationPart from '../atom_word_card_parts/index.term-and-pronunciation'
 import WordCardDefinitionPart from '../atom_word_card_parts/index.definition'
 import WordCardExampleReaderPart from '../atom_word_card_parts/index.example-reader'
+import { getLanguageCountryEmoji } from '@/global.constants'
 interface Props {
   word: WordData
 }
@@ -47,7 +48,7 @@ const WordCardReviewMode: FC<Props> = ({ word }) => {
           {isPeekMode && <WordCardTermAndPronunciationPart word={word} />}
           {!isPeekMode && (
             <Typography variant="h5" component="div">
-              {`???`}
+              {getLanguageCountryEmoji(word.languageCode) + ` ???`}
             </Typography>
           )}
           <WordCardDefinitionPart word={word} hideSubDefinition={!isPeekMode} />

--- a/src/global.constants.ts
+++ b/src/global.constants.ts
@@ -59,3 +59,12 @@ export const getLanguageFullName = (
 
   return `Unsupported Language`
 }
+
+export const getLanguageCountryEmoji = (
+  languageCode: GlobalLanguageCode,
+): string => {
+  const got = PROTECTED_AVAILABLE_LANGUAGE_MAP.get(languageCode)
+  if (got !== undefined) return got.flagUnicode
+
+  return `` // just return empty string
+}


### PR DESCRIPTION
# Background
Show the country code (based on language) to review easier:
![image](https://github.com/user-attachments/assets/a8848a20-923c-490c-9210-1ffce385ab02)

## What's done
### Non Peak Mode
![image](https://github.com/user-attachments/assets/a8848a20-923c-490c-9210-1ffce385ab02)
### Peak Mode
![image](https://github.com/user-attachments/assets/2a0257ca-dc7f-43c7-9058-759f02314e1e)

## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


