### PR TITLE
Feat/warning with deletion of word

### DIFF
--- a/src/components/atom_word_card_parts/index.delete-button.tsx
+++ b/src/components/atom_word_card_parts/index.delete-button.tsx
@@ -1,18 +1,34 @@
 import StyledIconButtonAtom from '@/atoms/StyledIconButton'
-import { FC } from 'react'
+import { FC, Fragment, useCallback, useState } from 'react'
 import DeleteWordIcon from '@mui/icons-material/Delete'
 import { useDeleteWord } from '@/hooks/words/use-delete-word.hook'
+import StyledTextButtonAtom from '@/atoms/StyledTextButton'
 interface Props {
   wordId: string
 }
 const WordCardDeleteButtonPart: FC<Props> = ({ wordId }) => {
+  const [isDoubleChecking, setDoubleChecking] = useState(false)
   const [isDeleting, onDeleteWord] = useDeleteWord(wordId)
+
+  const onClick = useCallback(() => {
+    setDoubleChecking(!isDoubleChecking)
+  }, [isDoubleChecking])
+
+  // TODO: Use memo
+  const jsxElementButton = isDoubleChecking ? (
+    <Fragment>
+      <StyledTextButtonAtom title={`Delete!`} onClick={onDeleteWord} />
+      <StyledTextButtonAtom title={`No!`} onClick={onClick} />
+    </Fragment>
+  ) : (
+    <DeleteWordIcon />
+  )
 
   return (
     <StyledIconButtonAtom
       isDisabled={isDeleting}
-      onClick={onDeleteWord}
-      jsxElementButton={<DeleteWordIcon />}
+      onClick={onClick}
+      jsxElementButton={jsxElementButton}
     />
   )
 }

--- a/src/components/atom_word_card_parts/index.delete-button.tsx
+++ b/src/components/atom_word_card_parts/index.delete-button.tsx
@@ -5,7 +5,7 @@ import { useDeleteWord } from '@/hooks/words/use-delete-word.hook'
 interface Props {
   wordId: string
 }
-const WordCardDeleteButton: FC<Props> = ({ wordId }) => {
+const WordCardDeleteButtonPart: FC<Props> = ({ wordId }) => {
   const [isDeleting, onDeleteWord] = useDeleteWord(wordId)
 
   return (
@@ -17,4 +17,4 @@ const WordCardDeleteButton: FC<Props> = ({ wordId }) => {
   )
 }
 
-export default WordCardDeleteButton
+export default WordCardDeleteButtonPart

--- a/src/components/atom_word_card_parts/index.delete-button.tsx
+++ b/src/components/atom_word_card_parts/index.delete-button.tsx
@@ -3,6 +3,7 @@ import { FC, Fragment, useCallback, useState } from 'react'
 import DeleteWordIcon from '@mui/icons-material/Delete'
 import { useDeleteWord } from '@/hooks/words/use-delete-word.hook'
 import StyledTextButtonAtom from '@/atoms/StyledTextButton'
+
 interface Props {
   wordId: string
 }
@@ -19,13 +20,16 @@ const WordCardDeleteButtonPart: FC<Props> = ({ wordId }) => {
       <Fragment>
         <StyledTextButtonAtom
           isDisabled={isDeleting}
-          title={`No!`}
+          title={`Oops, Go Back!`}
           onClick={onClick}
         />
-        <StyledTextButtonAtom
+        <StyledIconButtonAtom
           isDisabled={isDeleting}
-          title={`Delete!`}
           onClick={onDeleteWord}
+          jsxElementButton={<DeleteWordIcon />}
+          hoverMessage={{
+            title: `Click this to permanently delete this word`,
+          }}
         />
       </Fragment>
     )

--- a/src/components/atom_word_card_parts/index.delete-button.tsx
+++ b/src/components/atom_word_card_parts/index.delete-button.tsx
@@ -14,21 +14,27 @@ const WordCardDeleteButtonPart: FC<Props> = ({ wordId }) => {
     setDoubleChecking(!isDoubleChecking)
   }, [isDoubleChecking])
 
-  // TODO: Use memo
-  const jsxElementButton = isDoubleChecking ? (
-    <Fragment>
-      <StyledTextButtonAtom title={`Delete!`} onClick={onDeleteWord} />
-      <StyledTextButtonAtom title={`No!`} onClick={onClick} />
-    </Fragment>
-  ) : (
-    <DeleteWordIcon />
-  )
+  if (isDoubleChecking)
+    return (
+      <Fragment>
+        <StyledTextButtonAtom
+          isDisabled={isDeleting}
+          title={`No!`}
+          onClick={onClick}
+        />
+        <StyledTextButtonAtom
+          isDisabled={isDeleting}
+          title={`Delete!`}
+          onClick={onDeleteWord}
+        />
+      </Fragment>
+    )
 
   return (
     <StyledIconButtonAtom
       isDisabled={isDeleting}
       onClick={onClick}
-      jsxElementButton={jsxElementButton}
+      jsxElementButton={<DeleteWordIcon />}
     />
   )
 }

--- a/src/components/molecule_word_card/index.editing_mode.tsx
+++ b/src/components/molecule_word_card/index.editing_mode.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { Card, CardActions, CardContent, Stack, Box } from '@mui/material'
 import WordCardFavoriteIcon from '../atom_word_card_favorite_icon'
-import WordCardDeleteButton from '../atom_word_card_delete_button'
+import WordCardDeleteButtonPart from '../atom_word_card_parts/index.delete-button'
 import StyledSuspense from '@/organisms/StyledSuspense'
 import WordCardEditingTextField from '../molecule_word_card_editing_text_field'
 import LanguageSelector from '../atom_language_selector'
@@ -36,7 +36,7 @@ const WordCardEditingMode: FC<Props> = ({ wordId }) => {
         </CardContent>
         <CardActions>
           <WordCardFavoriteIcon wordId={wordId} />
-          <WordCardDeleteButton wordId={wordId} />
+          <WordCardDeleteButtonPart wordId={wordId} />
           <Box flexGrow={1} />
           <WordCardConfirmModifyButton wordId={wordId} />
         </CardActions>

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { Card, CardActions, CardContent, Stack } from '@mui/material'
 import WordCardFavoriteIcon from '../atom_word_card_favorite_icon'
-import WordCardDeleteButton from '../atom_word_card_delete_button'
+import WordCardDeleteButtonPart from '../atom_word_card_parts/index.delete-button'
 import WordCardDeleted from './index.deleted'
 import { useRecoilCallback, useRecoilValue } from 'recoil'
 import WordCardUnknown from './index.unknown'
@@ -72,7 +72,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
             >
               <Stack direction={`row`} alignItems={`center`}>
                 <WordCardFavoriteIcon wordId={wordId} />
-                <WordCardDeleteButton wordId={wordId} />
+                <WordCardDeleteButtonPart wordId={wordId} />
                 {!word.isArchived && (
                   <WordCardArchiveButtonPart wordId={wordId} />
                 )}


### PR DESCRIPTION
# Background
Some of users often accidentally click the delete button:
![image](https://github.com/user-attachments/assets/882cfbcc-9f00-4c3f-96a2-f92531ba5db1)

We want to make a double confirming mechanism so that users don't delete words accidentally.

## What's done
If original delete button is clicked, it becomes the following:
- Red: Go back to original mode
- Blue: Really Delete the word
- Green: Hover message
![image](https://github.com/user-attachments/assets/5e118365-b5cf-4f8d-812a-2b1983ac1189)


## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


