### PR TITLE
Feat: `PinButton` for WordCard

### DIFF
--- a/src/api/words/interfaces/index.search-params.ts
+++ b/src/api/words/interfaces/index.search-params.ts
@@ -8,6 +8,7 @@ export interface GetWordParams extends GetReqDtoRoot {
   languageCodes: GlobalLanguageCode[]
   semester: number
   isFavorite: boolean
+  isPinned: boolean
   term: string
   pronunciation: string
   definition: string

--- a/src/api/words/interfaces/index.ts
+++ b/src/api/words/interfaces/index.ts
@@ -19,6 +19,7 @@ export interface WordData extends ISharedWord, DataStatus, DataBasics {
   userId: string
   semester: number
   isFavorite: boolean
+  isPinned: boolean
   dateAdded?: number
   isArchived: boolean
 }

--- a/src/atoms/StyledIconButtonPin.tsx
+++ b/src/atoms/StyledIconButtonPin.tsx
@@ -15,7 +15,7 @@ const StyledIconButtonPin: FC<Props> = ({ isClicked, onClick, size }) => {
       jsxElementButton={
         <PushPinIcon
           style={{
-            color: isClicked ? `ffa31a` /* Orange */ : undefined,
+            color: isClicked ? /* Orange */ `ffa31a` : undefined,
             fontSize: size,
           }}
         />

--- a/src/atoms/StyledIconButtonPin.tsx
+++ b/src/atoms/StyledIconButtonPin.tsx
@@ -1,0 +1,27 @@
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+import { FC } from 'react'
+import { GlobalMuiSize } from '@/global.interface'
+import PushPinIcon from '@mui/icons-material/PushPin'
+
+interface Props {
+  isClicked: boolean
+  onClick?: () => any
+  size?: GlobalMuiSize
+}
+const StyledIconButtonPin: FC<Props> = ({ isClicked, onClick, size }) => {
+  return (
+    <StyledIconButtonAtom
+      onClick={onClick}
+      jsxElementButton={
+        <PushPinIcon
+          style={{
+            color: isClicked ? `ffa31a` /* Orange */ : undefined,
+            fontSize: size,
+          }}
+        />
+      }
+    />
+  )
+}
+
+export default StyledIconButtonPin

--- a/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
+++ b/src/components/atom_shared_word_card_parts/index.add-word-button.tsx
@@ -24,6 +24,7 @@ const SharedWordCardAddWordButtonPart: FC<Props> = ({ wordId }) => {
 
       await onPostWord({
         isFavorite: false,
+        isPinned: false,
         isArchived: false,
         term: sharedWord.word.term,
         pronunciation: sharedWord.word.pronunciation,

--- a/src/components/atom_word_card_favorite_icon/index.tsx
+++ b/src/components/atom_word_card_favorite_icon/index.tsx
@@ -5,6 +5,7 @@ import StyledIconButtonFavorite from '@/atoms/StyledIconButtonFavorite'
 interface Props {
   wordId: string
 }
+// TODO: Move to the "atom_word_card_part"
 const WordCardFavoriteIcon: FC<Props> = ({ wordId }) => {
   const [word, onPutWordFavorite] = usePutWordFavorite(wordId)
 

--- a/src/components/atom_word_card_parts/index.pin-button.tsx
+++ b/src/components/atom_word_card_parts/index.pin-button.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react'
+import StyledIconButtonPin from '@/atoms/StyledIconButtonPin'
+import { usePutWordIsPinned } from '@/hooks/words/use-put-word-is-pinned.hook'
+
+interface Props {
+  wordId: string
+}
+
+const WordCardPinButtonPart: FC<Props> = ({ wordId }) => {
+  const [word, onPutWordIsPinned] = usePutWordIsPinned(wordId)
+
+  if (!word) return null
+
+  return (
+    <StyledIconButtonPin
+      isClicked={word.isPinned}
+      onClick={onPutWordIsPinned}
+    />
+  )
+}
+
+export default WordCardPinButtonPart

--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -62,7 +62,7 @@ const WordCardReviewMode: FC<Props> = ({ word }) => {
               alignItems={`left`}
             >
               <Stack direction={`row`} alignItems={`center`} pr={0.5}>
-                {isPeekMode && <WordCardPinButtonPart wordId={word.id} />}
+                <WordCardPinButtonPart wordId={word.id} />
                 <WordCardFavoriteIcon wordId={word.id} />
                 <StyledVisibilityAtom
                   isVisible={!isPeekMode}

--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -24,6 +24,7 @@ import WordCardTermAndPronunciationPart from '../atom_word_card_parts/index.term
 import WordCardDefinitionPart from '../atom_word_card_parts/index.definition'
 import WordCardExampleReaderPart from '../atom_word_card_parts/index.example-reader'
 import { getLanguageCountryEmoji } from '@/global.constants'
+import WordCardPinButtonPart from '../atom_word_card_parts/index.pin-button'
 interface Props {
   word: WordData
 }
@@ -61,6 +62,7 @@ const WordCardReviewMode: FC<Props> = ({ word }) => {
               alignItems={`left`}
             >
               <Stack direction={`row`} alignItems={`center`} pr={0.5}>
+                {isPeekMode && <WordCardPinButtonPart wordId={word.id} />}
                 <WordCardFavoriteIcon wordId={word.id} />
                 <StyledVisibilityAtom
                   isVisible={!isPeekMode}

--- a/src/components/molecule_word_card/index.tsx
+++ b/src/components/molecule_word_card/index.tsx
@@ -28,6 +28,7 @@ import { useWindowSize } from 'react-use'
 import WordCardTermAndPronunciationPart from '../atom_word_card_parts/index.term-and-pronunciation'
 import WordCardDefinitionPart from '../atom_word_card_parts/index.definition'
 import WordCardExampleReaderPart from '../atom_word_card_parts/index.example-reader'
+import WordCardPinButtonPart from '../atom_word_card_parts/index.pin-button'
 
 interface Props {
   wordId: string
@@ -71,6 +72,7 @@ const WordCard: FC<Props> = ({ wordId, editingMode }) => {
               alignItems={`left`}
             >
               <Stack direction={`row`} alignItems={`center`} pr={0.5}>
+                <WordCardPinButtonPart wordId={wordId} />
                 <WordCardFavoriteIcon wordId={wordId} />
                 <WordCardDeleteButtonPart wordId={wordId} />
                 {!word.isArchived && (

--- a/src/hooks/words/use-put-word-is-pinned.hook.ts
+++ b/src/hooks/words/use-put-word-is-pinned.hook.ts
@@ -4,8 +4,8 @@ import { wordsFamily } from '@/recoil/words/words.state'
 import { usePutWord } from '@/hooks/words/use-put-word.hook'
 import { WordData } from '@/api/words/interfaces'
 
-type UsePutWord = [undefined | null | WordData, () => Promise<void>]
-export const usePutWordIsPinned = (wordId: string): UsePutWord => {
+type UsePutWordIsPinned = [undefined | null | WordData, () => Promise<void>]
+export const usePutWordIsPinned = (wordId: string): UsePutWordIsPinned => {
   const word = useRecoilValue(wordsFamily(wordId))
 
   const [, onPutWord] = usePutWord(wordId)

--- a/src/hooks/words/use-put-word-is-pinned.hook.ts
+++ b/src/hooks/words/use-put-word-is-pinned.hook.ts
@@ -11,10 +11,8 @@ export const usePutWordIsPinned = (wordId: string): UsePutWordIsPinned => {
   const [, onPutWord] = usePutWord(wordId)
 
   const onPutPinned = useCallback(async () => {
-    if (word == null) return
-
-    const modifyingTo = !word.isPinned
-    await onPutWord({ isPinned: modifyingTo })
+    if (word == null) return // nothing can be done with unknown word
+    await onPutWord({ isPinned: !word.isPinned })
   }, [word, onPutWord])
 
   return [word, onPutPinned]

--- a/src/hooks/words/use-put-word-is-pinned.hook.ts
+++ b/src/hooks/words/use-put-word-is-pinned.hook.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react'
+import { useRecoilValue } from 'recoil'
+import { wordsFamily } from '@/recoil/words/words.state'
+import { usePutWord } from '@/hooks/words/use-put-word.hook'
+import { WordData } from '@/api/words/interfaces'
+
+type UsePutWord = [undefined | null | WordData, () => Promise<void>]
+export const usePutWordIsPinned = (wordId: string): UsePutWord => {
+  const word = useRecoilValue(wordsFamily(wordId))
+
+  const [, onPutWord] = usePutWord(wordId)
+
+  const onPutPinned = useCallback(async () => {
+    if (word == null) return
+
+    const modifyingTo = !word.isPinned
+    await onPutWord({ isPinned: modifyingTo })
+  }, [word, onPutWord])
+
+  return [word, onPutPinned]
+}

--- a/src/lambdas/parse-input-into-word.lambda.ts
+++ b/src/lambdas/parse-input-into-word.lambda.ts
@@ -51,6 +51,7 @@ export const parseInputIntoWordLambda = (given: string): PostWordReqDto => {
     subDefinition: ``,
     exampleLink: ``,
     isFavorite: false,
+    isPinned: false,
     tags,
     isArchived: false, // every word parsed through is always non-archived
   }

--- a/src/recoil/words/words.selectors.ts
+++ b/src/recoil/words/words.selectors.ts
@@ -11,6 +11,7 @@ import { isEveryFavoriteSelectedState } from './semesters.state'
 enum Prk {
   SelectedSemester = `SelectedSemester`,
   IsFavoriteClicked = `IsFavoriteClicked`,
+  IsPinnedClickedSelector = `isPinnedClickedSelector`,
   SelectedCustomized = `SelectedCustomized`,
   SelectedLanguage = `SelectedLanguage`,
   SelectedDaysAgo = `SelectedDaysAgo`,
@@ -30,6 +31,13 @@ export const isFavoriteClickedSelector = selector<boolean>({
   key: Rkp.Tags + Prk.IsFavoriteClicked + Rks.Selector,
   get: ({ get }) => {
     return !!get(getWordsParamsState).isFavorite
+  },
+})
+
+export const isPinnedClickedSelector = selector<boolean>({
+  key: Rkp.Tags + Prk.IsPinnedClickedSelector + Rks.Selector,
+  get: ({ get }) => {
+    return !!get(getWordsParamsState).isPinned
   },
 })
 


### PR DESCRIPTION
# Background
![image](https://github.com/user-attachments/assets/ba9f5ee8-7da4-4763-9703-19c6034b70fe)
*The same Background as the following PR: https://github.com/ajktown/api/pull/159*

## What's done
Pin the word to make it listed on the top of the list all the time:
![image](https://github.com/user-attachments/assets/18807e0c-1ec4-4427-855d-a8fb855ab3b4)

## What are the related PRs?
- Depends on the following API PR: https://github.com/ajktown/api/pull/159

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


