### PR TITLE
Bugfix: Cannot Re-Modify Word After Using `Command` + `Enter` 

### DIFF
--- a/src/hooks/use-key-press.hook.ts
+++ b/src/hooks/use-key-press.hook.ts
@@ -29,6 +29,7 @@ export const useKeyPress = (
     const onKeyUp = () => {
       // instead of deleting a specific key like keysPressed.delete(event.key), we need to clear all keys
       // as any press up will be considered "not pressed" for the next key press
+      // This used to have the bug described in the issue https://github.com/ajktown/wordnote/issues/241
       keysPressed.clear()
     }
 

--- a/src/hooks/use-key-press.hook.ts
+++ b/src/hooks/use-key-press.hook.ts
@@ -13,9 +13,7 @@ export const useKeyPress = (
       // to not run onKeyPress() during composing (especially Japanese or Chinese where character conversion is required)
       if (event.isComposing) return
 
-      console.log(keysPressed)
       keysPressed.add(event.key)
-      console.log(event.isComposing)
 
       // TODO: Check the length too here:
       // if (secondKey === undefined && keysPressed.size !== 1) return

--- a/src/hooks/use-key-press.hook.ts
+++ b/src/hooks/use-key-press.hook.ts
@@ -13,7 +13,9 @@ export const useKeyPress = (
       // to not run onKeyPress() during composing (especially Japanese or Chinese where character conversion is required)
       if (event.isComposing) return
 
+      console.log(keysPressed)
       keysPressed.add(event.key)
+      console.log(event.isComposing)
 
       // TODO: Check the length too here:
       // if (secondKey === undefined && keysPressed.size !== 1) return
@@ -26,8 +28,10 @@ export const useKeyPress = (
       onKeyPress()
     }
 
-    const onKeyUp = (event: KeyboardEvent) => {
-      keysPressed.delete(event.key)
+    const onKeyUp = () => {
+      // instead of deleting a specific key like keysPressed.delete(event.key), we need to clear all keys
+      // as any press up will be considered "not pressed" for the next key press
+      keysPressed.clear()
     }
 
     document.addEventListener(`keydown`, onKeyDown)


### PR DESCRIPTION
# Background
![image](https://github.com/user-attachments/assets/8d26b1ac-96ac-4077-811c-3301a904d562)
https://github.com/ajktown/wordnote/issues/241

## What's done
Bug fixed.

## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


