### PR TITLE
Fix: Review Mode Word Card Language Flag Position

### DIFF
--- a/src/components/atom_word_card_parts/index.definition.tsx
+++ b/src/components/atom_word_card_parts/index.definition.tsx
@@ -12,8 +12,8 @@ const WordCardDefinitionPart: FC<Props> = ({ word, hideSubDefinition }) => {
   return (
     <Stack spacing={0}>
       <Typography variant="body2">
+        {hideSubDefinition && getLanguageCountryEmoji(word.languageCode)}
         {word.definition}
-        {!hideSubDefinition && getLanguageCountryEmoji(word.languageCode)}
       </Typography>
       {!hideSubDefinition && word.subDefinition && (
         <Typography variant="body2" color="text.secondary" fontStyle={`italic`}>

--- a/src/components/atom_word_card_parts/index.definition.tsx
+++ b/src/components/atom_word_card_parts/index.definition.tsx
@@ -1,4 +1,5 @@
 import { ISharedWord } from '@/api/words/interfaces'
+import { getLanguageCountryEmoji } from '@/global.constants'
 import { Stack, Typography } from '@mui/material'
 import { FC } from 'react'
 
@@ -10,7 +11,10 @@ interface Props {
 const WordCardDefinitionPart: FC<Props> = ({ word, hideSubDefinition }) => {
   return (
     <Stack spacing={0}>
-      <Typography variant="body2">{word.definition}</Typography>
+      <Typography variant="body2">
+        {word.definition}
+        {!hideSubDefinition && getLanguageCountryEmoji(word.languageCode)}
+      </Typography>
       {!hideSubDefinition && word.subDefinition && (
         <Typography variant="body2" color="text.secondary" fontStyle={`italic`}>
           {word.subDefinition}

--- a/src/components/molecule_word_card/index.review_mode.tsx
+++ b/src/components/molecule_word_card/index.review_mode.tsx
@@ -23,7 +23,6 @@ import { useWindowSize } from 'react-use'
 import WordCardTermAndPronunciationPart from '../atom_word_card_parts/index.term-and-pronunciation'
 import WordCardDefinitionPart from '../atom_word_card_parts/index.definition'
 import WordCardExampleReaderPart from '../atom_word_card_parts/index.example-reader'
-import { getLanguageCountryEmoji } from '@/global.constants'
 import WordCardPinButtonPart from '../atom_word_card_parts/index.pin-button'
 interface Props {
   word: WordData
@@ -49,7 +48,7 @@ const WordCardReviewMode: FC<Props> = ({ word }) => {
           {isPeekMode && <WordCardTermAndPronunciationPart word={word} />}
           {!isPeekMode && (
             <Typography variant="h5" component="div">
-              {getLanguageCountryEmoji(word.languageCode) + ` ???`}
+              {`???`}
             </Typography>
           )}
           <WordCardDefinitionPart word={word} hideSubDefinition={!isPeekMode} />


### PR DESCRIPTION
# Background
I found myself not catching the flag during the review mode.

## What's done?
![image](https://github.com/user-attachments/assets/330d6baa-ddec-479b-a3d7-a5a35cc6b161)
Into
![image](https://github.com/user-attachments/assets/6fd56a2a-c355-4fbd-bbd8-06d075f240dd)


## What are the related PRs?
None

## What's next?
None

## Checklist Before PR Review
- [x] The following has been handled:
  - `Title` is checked
  - `Background` is filled
  - `What's done?` is filled
  - `What are the related PRs?` is filled
  - `What's next?` is filled
  - `Draft` is set for this PR
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done, if frontend related
  - Make this PR as an open PR
  - Double-check `What's done?` matches to the actual changes
  - Appropriate ajktown/docs sync pr done if needed

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists
  - Check if appropriate issues are created from `What's next?`


