### PR TITLE
Feat: `jotai` as a sample, replacing Recoil React

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "country-flag-icons": "^1.5.19",
     "deep-object-diff": "^1.1.9",
     "iso-639-1": "^3.1.5",
+    "jotai": "^2.12.5",
     "js-cookie": "^3.0.5",
     "luxon": "^3.6.1",
     "next": "15.3.2",

--- a/src/components/atom_word_card_parts/index.share-button.tsx
+++ b/src/components/atom_word_card_parts/index.share-button.tsx
@@ -12,11 +12,10 @@ const WordCardShareButtonPart: FC<Props> = ({ wordId }) => {
   const [, setSharedWordId] = useAtom(sharedWordIdState)
 
   const onClick = useCallback(() => {
-    const handle = async () => {
+    ;(async () => {
       setSharedWordId(wordId)
       await onGetSharedResource()
-    }
-    handle()
+    })()
   }, [wordId, onGetSharedResource, setSharedWordId])
 
   return (

--- a/src/components/atom_word_card_parts/index.share-button.tsx
+++ b/src/components/atom_word_card_parts/index.share-button.tsx
@@ -1,23 +1,23 @@
 import StyledIconButtonAtom from '@/atoms/StyledIconButton'
-import { FC } from 'react'
+import { FC, useCallback } from 'react'
 import ShareIcon from '@mui/icons-material/Share'
 import { useSharedResource } from '@/hooks/shared-resources/use-shared-resource.hook'
-import { useRecoilCallback } from 'recoil'
 import { sharedWordIdState } from '@/recoil/shared-resource/shared-resource.state'
+import { useAtom } from 'jotai'
 interface Props {
   wordId: string
 }
 const WordCardShareButtonPart: FC<Props> = ({ wordId }) => {
   const onGetSharedResource = useSharedResource(wordId)
+  const [, setSharedWordId] = useAtom(sharedWordIdState)
 
-  const onClick = useRecoilCallback(
-    ({ set }) =>
-      async () => {
-        set(sharedWordIdState, wordId)
-        await onGetSharedResource()
-      },
-    [wordId, onGetSharedResource],
-  )
+  const onClick = useCallback(() => {
+    const handle = async () => {
+      setSharedWordId(wordId)
+      await onGetSharedResource()
+    }
+    handle()
+  }, [wordId, onGetSharedResource, setSharedWordId])
 
   return (
     <StyledIconButtonAtom onClick={onClick} jsxElementButton={<ShareIcon />} />

--- a/src/components/dialog_shared_resource/index.tsx
+++ b/src/components/dialog_shared_resource/index.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from 'react'
-import { useRecoilCallback, useRecoilValue, useResetRecoilState } from 'recoil'
+import { useRecoilCallback, useRecoilValue } from 'recoil'
 import {
   sharedWordFamily,
   sharedWordIdState,
@@ -11,18 +11,21 @@ import { postSharedResourceApi } from '@/api/shared-resources/post-shared-resour
 import WordCardShared from '../molecule_word_card/index.shared'
 import { DialogContent, DialogTitle } from '@mui/material'
 import WordCardShareReview from '../molecule_word_card/index.share-review'
+import { useAtom } from 'jotai'
+import { useResetAtom } from 'jotai/utils'
 
 const SharedResourceDialog: FC = () => {
-  const sharedWordId = useRecoilValue(sharedWordIdState)
+  const [sharedWordId, setSharedWordIdState] = useAtom(sharedWordIdState)
   const sharedWord = useRecoilValue(sharedWordFamily(sharedWordId))
-  const onClose = useResetRecoilState(sharedWordIdState)
+  const onClose = useResetAtom(sharedWordIdState)
+
   const [posting, setPosting] = useState(false)
 
   const onClick = useRecoilCallback(
     ({ set }) =>
       async () => {
         setPosting(true)
-        set(sharedWordIdState, sharedWordId)
+        setSharedWordIdState(sharedWordId)
         try {
           const [data] = await postSharedResourceApi({
             wordId: sharedWordId,
@@ -35,7 +38,7 @@ const SharedResourceDialog: FC = () => {
           setPosting(false)
         }
       },
-    [sharedWordId],
+    [sharedWordId, setSharedWordIdState],
   )
 
   if (!sharedWordId) return null

--- a/src/recoil/shared-resource/shared-resource.state.ts
+++ b/src/recoil/shared-resource/shared-resource.state.ts
@@ -1,6 +1,7 @@
-import { atom, atomFamily } from 'recoil'
+import { atomFamily } from 'recoil'
 import { Rkp, Rks } from '@/recoil/index.keys'
 import { GetSharedResourceRes } from '@/api/shared-resources/get-shared-resource.api'
+import { atomWithReset } from 'jotai/utils'
 
 /** Private Recoil Key */
 enum Prk {
@@ -11,10 +12,7 @@ enum Prk {
 /**
  * The modal will appear if it is set non empty
  */
-export const sharedWordIdState = atom<string>({
-  key: Rkp.SharedResource + Prk.SharedWordId,
-  default: ``,
-})
+export const sharedWordIdState = atomWithReset<string>(``)
 
 type SharedWordFamily =
   | undefined // not requested (loading)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4626,6 +4626,11 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
+jotai@^2.12.5:
+  version "2.12.5"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.12.5.tgz#2decdf41dfcad5e4afc7278da81c45646d4ae8ad"
+  integrity sha512-G8m32HW3lSmcz/4mbqx0hgJIQ0ekndKWiYP7kWVKi0p6saLXdSoye+FZiOFyonnd7Q482LCzm8sMDl7Ar1NWDw==
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"


### PR DESCRIPTION
# Background
React Recoil has not been maintained for long time after the massive layoff around 2023

## What's done?
I would like to import the package manager `jotai` replacing the Recoil

## What are the related PRs?
None

## What's next?
Gradually replace other Recoil stuff 

## Checklist Before PR Review
- [x] The following has been handled:
  - `Title` is checked
  - `Background` is filled
  - `What's done?` is filled
  - `What are the related PRs?` is filled
  - `What's next?` is filled
  - `Draft` is set for this PR
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done, if frontend related
  - Make this PR as an open PR
  - Double-check `What's done?` matches to the actual changes
  - Appropriate ajktown/docs sync pr done if needed

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists
  - Check if appropriate issues are created from `What's next?`


